### PR TITLE
docs: add README + CHANGELOG; raise restrictive() pixel cap 100→120 MP

### DIFF
--- a/zenjxl-decoder/CHANGELOG.md
+++ b/zenjxl-decoder/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to `zenjxl-decoder` are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/); this crate uses 0.x semver
+(minor = breaking, patch = additive/fixes).
+
+## [Unreleased]
+
+### Added
+- `README.md` (the crate previously shipped without one): quick start, the
+  server-safety story (resource-limit presets + cooperative cancellation), all
+  entry points, the feature matrix, and the `#[non_exhaustive]`
+  mutate-after-`default()` idiom for configuring `JxlDecoderOptions`.
+
+### Changed
+- `JxlDecoderLimits::restrictive()` raises `max_pixels` from 100 MP to **120 MP**
+  so common ~108 MP camera photos pass an untrusted-web policy while >120 MP
+  decompression bombs are still rejected.

--- a/zenjxl-decoder/README.md
+++ b/zenjxl-decoder/README.md
@@ -1,0 +1,82 @@
+# zenjxl-decoder ![CI](https://img.shields.io/github/actions/workflow/status/imazen/zenjxl-decoder/ci.yml?style=flat-square&label=CI) ![crates.io](https://img.shields.io/crates/v/zenjxl-decoder?style=flat-square) [![lib.rs](https://img.shields.io/crates/v/zenjxl-decoder?style=flat-square&label=lib.rs&color=blue)](https://lib.rs/crates/zenjxl-decoder) ![docs.rs](https://img.shields.io/docsrs/zenjxl-decoder?style=flat-square) ![License](https://img.shields.io/crates/l/zenjxl-decoder?style=flat-square)
+
+A pure-Rust **JPEG XL decoder** (ISO/IEC 18181), built for decoding untrusted bytes in a server.
+
+`zenjxl-decoder` is a fork of the upstream [`libjxl/jxl-rs`](https://github.com/libjxl/jxl-rs) reference decoder. Upstream remains the source of truth for codec behaviour; this fork adds the things a production service needs on top: enforced resource limits, cooperative cancellation, parallel decode, and `#![forbid(unsafe_code)]` by default.
+
+## Quick start
+
+```rust
+// Decode the first frame to interleaved 8-bit pixels.
+let bytes = std::fs::read("photo.jxl")?;
+let image = zenjxl_decoder::decode(&bytes)?;
+
+// `data` is row-major, tightly packed, RGBA (4 ch) or GrayAlpha (2 ch).
+assert_eq!(image.data.len(), image.width * image.height * image.channels);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+`decode` returns a [`JxlImage`] with `width`, `height`, `channels`, the pixel `data: Vec<u8>`, plus color profiles, EXIF, and an HDR `gain_map` when present. Alpha is always emitted (opaque where the source has none).
+
+Need just the dimensions? `read_header(&bytes)` parses the header without decoding pixels.
+
+## Decoding untrusted input (the server path)
+
+**The default already enforces limits** — `decode()` uses [`JxlDecoderLimits::default()`] (≈256 MP, 4 GB memory on 64-bit / 2 GB on 32-bit, capped channel/tree/spline/patch counts). Allocation derived from header fields is checked *before* it happens, so a malicious file is rejected, not OOM'd.
+
+For a web frontend, tighten further with `restrictive()`, and pass a cancellation handle so a slow decode can be aborted:
+
+`JxlDecoderOptions` is `#[non_exhaustive]`, so you configure it by mutating fields on a `default()` value (not a struct literal):
+
+```rust
+use std::sync::Arc;
+use zenjxl_decoder::{decode_with, api::{JxlDecoderOptions, JxlDecoderLimits}};
+use almost_enough::Stopper;
+
+let stop = Arc::new(Stopper::new());     // flip this from another thread / a timeout to cancel
+
+let mut options = JxlDecoderOptions::default();
+options.limits = JxlDecoderLimits::restrictive(); // 120 MP, 1 GB, tight counts — for untrusted web content
+options.stop = stop.clone();                       // cooperative cancellation; default is `Unstoppable` (no-op)
+options.reject_progressive = true;                 // optionally refuse progressive content
+
+// On another thread / timer:  stop.cancel();
+let image = decode_with(&bytes, options)?;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+Limit presets:
+
+| preset | max pixels | max memory | use for |
+|--------|-----------|-----------|---------|
+| `JxlDecoderLimits::default()` | ~256 MP | 4 GB (2 GB on 32-bit) | general decoding |
+| `JxlDecoderLimits::restrictive()` | 120 MP | 1 GB | untrusted web content |
+| `JxlDecoderLimits::unlimited()` | none | none | **trusted input only** |
+
+Every field is a `pub Option<_>` you can set individually (`max_pixels`, `max_memory_bytes`, `max_extra_channels`, `max_tree_size`, `max_patches`, `max_spline_points`, `max_reference_frames`, `max_icc_size`). `None` means "no limit" for that field. When a limit trips, decode returns an `Err` you can inspect — it is never a panic.
+
+Cancellation uses the [`enough`](https://crates.io/crates/enough) `Stop` trait. The default `stop` is `Arc::new(enough::Unstoppable)`, which the decoder checks periodically at no cost. To actually cancel, hand it an [`almost_enough::Stopper`](https://crates.io/crates/almost-enough) (or any `Stop`) and flip it from another thread or a timeout.
+
+## Other entry points
+
+- `decode_with(bytes, options)` — full control (limits, cancellation, parallel, CMS, premultiplied alpha).
+- `read_header(bytes)` / `read_header_with(bytes, limits)` — metadata only, no pixel decode.
+- `reconstruct_jpeg(bytes)` / `reconstruct_jpeg_with(..)` — losslessly reconstruct the original JPEG from a JXL that was transcoded from one (requires the `jpeg` feature).
+- The streaming [`JxlDecoder`] type (in `api`) decodes frame-by-frame for animation.
+
+## Features
+
+| feature | default | effect |
+|---------|---------|--------|
+| `all-simd` | ✅ | runtime SIMD dispatch (SSE4.2/AVX2/AVX-512/NEON/WASM128) via [`archmage`](https://crates.io/crates/archmage); per-ISA: `sse42`, `avx`, `avx512`, `neon`, `wasm128` |
+| `threads` | — | parallel group decode/render on the rayon global pool (`RAYON_NUM_THREADS` to size it) |
+| `cms` | — | ICC-aware color conversion via [`moxcms`](https://crates.io/crates/moxcms) |
+| `jpeg` | — | `reconstruct_jpeg*` (pulls in `brotli`) |
+
+## Safety
+
+The crate is `#![forbid(unsafe_code)]`; all SIMD is expressed through the safe [`archmage`](https://crates.io/crates/archmage) dispatch layer. There is no `unsafe` in the decode path.
+
+## License
+
+BSD-3-Clause, matching upstream `jxl-rs`. See [LICENSE](LICENSE).

--- a/zenjxl-decoder/src/api/decoder.rs
+++ b/zenjxl-decoder/src/api/decoder.rs
@@ -1685,7 +1685,7 @@ pub(crate) mod tests {
     fn test_restrictive_limits_preset() {
         // Verify the restrictive preset is reasonable
         let limits = crate::api::JxlDecoderLimits::restrictive();
-        assert_eq!(limits.max_pixels, Some(100_000_000));
+        assert_eq!(limits.max_pixels, Some(120_000_000));
         assert_eq!(limits.max_extra_channels, Some(16));
         assert_eq!(limits.max_icc_size, Some(1 << 20));
         assert_eq!(limits.max_tree_size, Some(1 << 20));

--- a/zenjxl-decoder/src/api/options.rs
+++ b/zenjxl-decoder/src/api/options.rs
@@ -102,7 +102,7 @@ impl JxlDecoderLimits {
     /// Returns restrictive limits suitable for untrusted web content.
     pub fn restrictive() -> Self {
         Self {
-            max_pixels: Some(100_000_000),    // 100 megapixels
+            max_pixels: Some(120_000_000),    // 120 megapixels (admits common ~108 MP camera photos)
             max_extra_channels: Some(16),     // 16 extra channels
             max_icc_size: Some(1 << 20),      // 1 MB
             max_tree_size: Some(1 << 20),     // 1M nodes


### PR DESCRIPTION
Part of a production-readiness sweep across the zen codecs (idiot-proof / server-safe / production-debuggable).

## What

- **Add `README.md`** — the crate shipped without one. Covers the server decode path: resource-limit presets (`default()` ~256 MP / `restrictive()` / `unlimited()`), cooperative cancellation via `enough`/`almost-enough` (`Arc<dyn Stop>`, default `Unstoppable`), all entry points (`decode` / `decode_with` / `read_header` / `reconstruct_jpeg`), the feature matrix, and `#![forbid(unsafe_code)]`.
- **Add `CHANGELOG.md`** — the crate had none.
- **`JxlDecoderLimits::restrictive()`: `max_pixels` 100 MP → 120 MP** — common ~108 MP camera photos now pass an untrusted-web policy, while >120 MP decompression bombs are still rejected. Preset assertion test updated.

## Why the README matters (footgun caught)

`JxlDecoderOptions` and `JxlDecoderLimits` are `#[non_exhaustive]` with **no builder methods**, so a downstream user **cannot** struct-literal-construct them (`JxlDecoderOptions { .. }` fails to compile outside the crate). The correct idiom is mutate-after-`default()`, which nothing documented. The README now shows it explicitly. (Tracking a follow-up to consider adding builder methods.)

## Validation

`cargo test -p zenjxl-decoder --lib test_restrictive_limits_preset` passes (built clean, peak-RSS 1.56 GiB). No public API change beyond the `restrictive()` default cap; no behavior change on the default/unlimited presets.