### PR TITLE
Add with_* builders to JxlDecoderOptions/JxlDecoderLimits (fixes #22)

### DIFF
--- a/docs/public-api/zenjxl-decoder.txt
+++ b/docs/public-api/zenjxl-decoder.txt
@@ -6,7 +6,7 @@
 # impls omitted; re-export duplicates annotated `[also: path]`.
 # DO NOT EDIT BY HAND — commit regenerated changes with the code.
 #
-# files: zenjxl-decoder.txt 609 lines (supported surface) | zenjxl-decoder.features.txt 12 added (features: all-simd,allow-unsafe,avx,avx512,cms,jpeg,moxcms,neon,profiling,rayon,sse42,threads,tracing,wasm128) | zenjxl-decoder.internal.txt 22 lines (22 hidden + 0 excluded-feature)
+# files: zenjxl-decoder.txt 630 lines (supported surface) | zenjxl-decoder.features.txt 12 added (features: all-simd,allow-unsafe,avx,avx512,cms,jpeg,moxcms,neon,profiling,rayon,sse42,threads,tracing,wasm128) | zenjxl-decoder.internal.txt 22 lines (22 hidden + 0 excluded-feature)
 
 ## summary
 #
@@ -15,7 +15,7 @@
 #   pub consts/statics                          2
 #   pub macros                                  1
 #   free functions                             10
-#   inherent methods                          160
+#   inherent methods                          181
 #   struct fields                             116
 #   enum variants                             209
 #   re-exports                                  2
@@ -25,9 +25,9 @@
 #
 # per-module pub lines:
 #   (root)                            8
-#   api                             544
+#   api                             565
 
-## items (548 lines)
+## items (569 lines)
 
 pub mod zenjxl_decoder
 pub mod api
@@ -458,6 +458,14 @@ pub api::JxlDecoderLimits::max_spline_points: core::option::Option<u32>
 pub api::JxlDecoderLimits::max_tree_size: core::option::Option<usize>
 pub fn api::JxlDecoderLimits::restrictive() -> Self
 pub fn api::JxlDecoderLimits::unlimited() -> Self
+pub fn api::JxlDecoderLimits::with_max_extra_channels(self, usize) -> Self
+pub fn api::JxlDecoderLimits::with_max_icc_size(self, usize) -> Self
+pub fn api::JxlDecoderLimits::with_max_memory_bytes(self, u64) -> Self
+pub fn api::JxlDecoderLimits::with_max_patches(self, usize) -> Self
+pub fn api::JxlDecoderLimits::with_max_pixels(self, usize) -> Self
+pub fn api::JxlDecoderLimits::with_max_reference_frames(self, usize) -> Self
+pub fn api::JxlDecoderLimits::with_max_spline_points(self, u32) -> Self
+pub fn api::JxlDecoderLimits::with_max_tree_size(self, usize) -> Self
 #[non_exhaustive] pub struct api::JxlDecoderOptions
 pub api::JxlDecoderOptions::adjust_orientation: bool
 pub api::JxlDecoderOptions::cms: core::option::Option<alloc::boxed::Box<dyn api::JxlCms>>
@@ -472,6 +480,19 @@ pub api::JxlDecoderOptions::reject_progressive: bool
 pub api::JxlDecoderOptions::render_spot_colors: bool
 pub api::JxlDecoderOptions::skip_preview: bool
 pub api::JxlDecoderOptions::stop: alloc::sync::Arc<dyn enough::Stop>
+pub fn api::JxlDecoderOptions::with_adjust_orientation(self, bool) -> Self
+pub fn api::JxlDecoderOptions::with_cms(self, alloc::boxed::Box<dyn api::JxlCms>) -> Self
+pub fn api::JxlDecoderOptions::with_coalescing(self, bool) -> Self
+pub fn api::JxlDecoderOptions::with_desired_intensity_target(self, f32) -> Self
+pub fn api::JxlDecoderOptions::with_high_precision(self, bool) -> Self
+pub fn api::JxlDecoderOptions::with_limits(self, api::JxlDecoderLimits) -> Self
+pub fn api::JxlDecoderOptions::with_parallel(self, bool) -> Self
+pub fn api::JxlDecoderOptions::with_premultiply_output(self, bool) -> Self
+pub fn api::JxlDecoderOptions::with_progressive_mode(self, api::JxlProgressiveMode) -> Self
+pub fn api::JxlDecoderOptions::with_reject_progressive(self, bool) -> Self
+pub fn api::JxlDecoderOptions::with_render_spot_colors(self, bool) -> Self
+pub fn api::JxlDecoderOptions::with_skip_preview(self, bool) -> Self
+pub fn api::JxlDecoderOptions::with_stop(self, alloc::sync::Arc<dyn enough::Stop>) -> Self
 pub struct api::JxlExtraChannel
 pub api::JxlExtraChannel::alpha_associated: bool
 pub api::JxlExtraChannel::bits_per_sample: u32

--- a/zenjxl-decoder/src/api/options.rs
+++ b/zenjxl-decoder/src/api/options.rs
@@ -112,6 +112,62 @@ impl JxlDecoderLimits {
             max_memory_bytes: Some(1 << 30),  // 1 GB total memory
         }
     }
+
+    /// Set the maximum total pixel count (width × height).
+    #[must_use]
+    pub fn with_max_pixels(mut self, max: usize) -> Self {
+        self.max_pixels = Some(max);
+        self
+    }
+
+    /// Set the maximum number of extra channels (alpha, depth, etc.).
+    #[must_use]
+    pub fn with_max_extra_channels(mut self, max: usize) -> Self {
+        self.max_extra_channels = Some(max);
+        self
+    }
+
+    /// Set the maximum ICC profile size in bytes.
+    #[must_use]
+    pub fn with_max_icc_size(mut self, max: usize) -> Self {
+        self.max_icc_size = Some(max);
+        self
+    }
+
+    /// Set the maximum modular tree size (number of nodes).
+    #[must_use]
+    pub fn with_max_tree_size(mut self, max: usize) -> Self {
+        self.max_tree_size = Some(max);
+        self
+    }
+
+    /// Set the maximum number of patches.
+    #[must_use]
+    pub fn with_max_patches(mut self, max: usize) -> Self {
+        self.max_patches = Some(max);
+        self
+    }
+
+    /// Set the maximum number of spline control points.
+    #[must_use]
+    pub fn with_max_spline_points(mut self, max: u32) -> Self {
+        self.max_spline_points = Some(max);
+        self
+    }
+
+    /// Set the maximum number of reference frames.
+    #[must_use]
+    pub fn with_max_reference_frames(mut self, max: usize) -> Self {
+        self.max_reference_frames = Some(max);
+        self
+    }
+
+    /// Set the maximum total memory budget in bytes.
+    #[must_use]
+    pub fn with_max_memory_bytes(mut self, max: u64) -> Self {
+        self.max_memory_bytes = Some(max);
+        self
+    }
 }
 
 pub enum JxlProgressiveMode {
@@ -123,6 +179,22 @@ pub enum JxlProgressiveMode {
     FullFrame,
 }
 
+/// Decoder configuration.
+///
+/// This struct is `#[non_exhaustive]`, so downstream crates **cannot** build it
+/// with a struct literal. Start from [`default`](Self::default) and chain the
+/// `with_*` setters (or assign the public fields on a `mut` binding):
+///
+/// ```
+/// use zenjxl_decoder::api::{JxlDecoderOptions, JxlDecoderLimits};
+///
+/// let options = JxlDecoderOptions::default()
+///     .with_limits(JxlDecoderLimits::restrictive().with_max_pixels(120_000_000))
+///     .with_reject_progressive(true);
+///
+/// assert!(options.reject_progressive);
+/// assert_eq!(options.limits.max_pixels, Some(120_000_000));
+/// ```
 #[non_exhaustive]
 pub struct JxlDecoderOptions {
     pub adjust_orientation: bool,
@@ -189,5 +261,99 @@ impl Default for JxlDecoderOptions {
             stop: Arc::new(enough::Unstoppable),
             parallel: cfg!(feature = "threads"),
         }
+    }
+}
+
+impl JxlDecoderOptions {
+    /// Apply EXIF orientation to the decoded image.
+    #[must_use]
+    pub fn with_adjust_orientation(mut self, v: bool) -> Self {
+        self.adjust_orientation = v;
+        self
+    }
+
+    /// Reject progressive content during frame decode (untrusted-input policy).
+    #[must_use]
+    pub fn with_reject_progressive(mut self, v: bool) -> Self {
+        self.reject_progressive = v;
+        self
+    }
+
+    /// Render spot colors.
+    #[must_use]
+    pub fn with_render_spot_colors(mut self, v: bool) -> Self {
+        self.render_spot_colors = v;
+        self
+    }
+
+    /// Coalesce animation frames onto the canvas.
+    #[must_use]
+    pub fn with_coalescing(mut self, v: bool) -> Self {
+        self.coalescing = v;
+        self
+    }
+
+    /// Set the desired display intensity target (nits).
+    #[must_use]
+    pub fn with_desired_intensity_target(mut self, nits: f32) -> Self {
+        self.desired_intensity_target = Some(nits);
+        self
+    }
+
+    /// Skip decoding the preview frame.
+    #[must_use]
+    pub fn with_skip_preview(mut self, v: bool) -> Self {
+        self.skip_preview = v;
+        self
+    }
+
+    /// Set the progressive rendering mode.
+    #[must_use]
+    pub fn with_progressive_mode(mut self, mode: JxlProgressiveMode) -> Self {
+        self.progressive_mode = mode;
+        self
+    }
+
+    /// Set the color-management system used for ICC conversions.
+    #[must_use]
+    pub fn with_cms(mut self, cms: Box<dyn JxlCms>) -> Self {
+        self.cms = Some(cms);
+        self
+    }
+
+    /// Use higher-precision decoding (slower).
+    #[must_use]
+    pub fn with_high_precision(mut self, v: bool) -> Self {
+        self.high_precision = v;
+        self
+    }
+
+    /// Emit premultiplied alpha in the output.
+    #[must_use]
+    pub fn with_premultiply_output(mut self, v: bool) -> Self {
+        self.premultiply_output = v;
+        self
+    }
+
+    /// Set the resource limits (see [`JxlDecoderLimits::restrictive`] for a
+    /// safe untrusted-input preset).
+    #[must_use]
+    pub fn with_limits(mut self, limits: JxlDecoderLimits) -> Self {
+        self.limits = limits;
+        self
+    }
+
+    /// Set the cooperative-cancellation token (an [`enough::Stop`]).
+    #[must_use]
+    pub fn with_stop(mut self, stop: Arc<dyn enough::Stop>) -> Self {
+        self.stop = stop;
+        self
+    }
+
+    /// Enable multi-threaded decoding (requires the `threads` feature).
+    #[must_use]
+    pub fn with_parallel(mut self, v: bool) -> Self {
+        self.parallel = v;
+        self
     }
 }


### PR DESCRIPTION
Fixes #22 (`#[non_exhaustive]` structs with no builder — the classic downstream trap).

## Problem
`JxlDecoderOptions` and `JxlDecoderLimits` are `#[non_exhaustive]` with all-public fields but **no `with_*` setters**. A downstream crate that reaches for a struct literal —
```rust
JxlDecoderOptions { limits, stop, ..Default::default() }
```
**does not compile** ("cannot create non-exhaustive struct using struct expression"), and the error gives no hint at the working mutate-after-`default()` idiom.

## Fix (additive, non-breaking)
The issue's proposed fix — `with_*` builder methods, so users can chain without touching public fields and the `#[non_exhaustive]` guarantee is preserved:

- **`JxlDecoderLimits`**: `with_max_pixels`, `with_max_extra_channels`, `with_max_icc_size`, `with_max_tree_size`, `with_max_patches`, `with_max_spline_points`, `with_max_reference_frames`, `with_max_memory_bytes`.
- **`JxlDecoderOptions`**: `with_adjust_orientation`, `with_reject_progressive`, `with_render_spot_colors`, `with_coalescing`, `with_desired_intensity_target`, `with_skip_preview`, `with_progressive_mode`, `with_cms`, `with_high_precision`, `with_premultiply_output`, `with_limits`, `with_stop`, `with_parallel`.

`JxlDecoderOptions` also gains a doc comment with a builder-chain **doctest** that is compiled as an *external* doctest (`use zenjxl_decoder::api::...`) — so it proves the builder works from outside the crate, which is exactly what the issue is about.

## Tests
Doctests pass; lib builds clean; public-API snapshot regenerated.
