### PR TITLE
docs(readme): note almost-enough is a separate crate (cancellation example footgun, refs #29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,15 @@ All limits return `Error::LimitExceeded { resource, actual, limit }` when exceed
 
 ### Cancellation
 
-The decoder accepts any [`enough::Stop`](https://docs.rs/enough) implementation:
+The decoder accepts any [`enough::Stop`](https://docs.rs/enough) implementation. The
+ready-made thread-safe `Stopper` used below lives in the separate
+[`almost-enough`](https://docs.rs/almost-enough) crate — add it with `cargo add
+almost-enough`. To avoid the extra dependency, implement `enough::Stop` on your own
+type instead (e.g. wrapping an `AtomicBool` whose `check()` returns
+`Err(enough::StopReason::Cancelled)` once set).
 
 ```rust
-use almost_enough::Stopper;
+use almost_enough::Stopper; // separate crate: `cargo add almost-enough`
 use std::sync::Arc;
 
 let stop = Arc::new(Stopper::new());


### PR DESCRIPTION
The README's Cancellation example does `use almost_enough::Stopper;`, but `almost-enough` is only a `[dev-dependency]` here — a user copying the example into their own project hits an unresolved-import compile error (exactly the kind of thing a fresh reader gets wrong). Added the `cargo add almost-enough` note + the no-extra-dep alternative (implement `enough::Stop` on your own `AtomicBool` wrapper). README-only. Refs #29.