### PR TITLE
feat(error)!: whereat At<Error> source locations — cold-origin instrumentation (closes #28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project is a fork of [libjxl/jxl-rs](https://github.com/libjxl/jxl-rs). The
 ### QUEUED BREAKING CHANGES
 <!-- Breaking changes that will ship together in the next major (or minor for 0.x) release.
      Add items here as you discover them. Do NOT ship these piecemeal -- batch them. -->
+- The public `Error` is now wrapped as [`whereat::At<Error>`](https://docs.rs/whereat)
+  via the `Result` alias, so decode errors carry a `file:line` source location for
+  server-side stack traces. Match on the cause with `e.error()` (borrow) or
+  `e.decompose().0` (owned); `into_inner()` is deprecated. The low-level
+  bitstream/entropy hot path keeps a bare `Error` (no `At<>` in inner loops);
+  only the frame/render/api layer carries the wrapper. (#28)
 
 ### Added
 - `JxlDecoderOptions::reject_progressive` (default `false`): when `true`, decode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,6 +1852,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "whereat"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab90f361db038ba3135da12c938c328fb43a012992101879e3d6ebccb4d7eba8"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,6 +2156,7 @@ dependencies = [
  "test-log",
  "thiserror",
  "tracing",
+ "whereat",
  "zenbench",
  "zenjxl-decoder-macros",
  "zenjxl-decoder-simd",

--- a/zenjxl-decoder/Cargo.toml
+++ b/zenjxl-decoder/Cargo.toml
@@ -28,6 +28,7 @@ aligned-vec = "0.6"
 bytemuck = { version = "1", features = ["derive"] }
 atomic_refcell = "0.1"
 smallvec = "1"
+whereat = { version = "0.1.5" }
 enough = { version = "0.4", features = ["std"] }
 brotli = { version = "8.0", default-features = false, features = ["std"], optional = true }
 paste = "1"

--- a/zenjxl-decoder/src/api/color.rs
+++ b/zenjxl-decoder/src/api/color.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use std::{borrow::Cow, fmt};
+use whereat::at;
 
 use crate::{
     color::tf::{hlg_to_scene, linear_to_pq_precise, pq_to_linear_precise},
@@ -452,7 +453,7 @@ impl JxlColorEncoding {
         let rendering_intent = internal.rendering_intent;
         if internal.color_space == ColorSpace::XYB {
             if rendering_intent != RenderingIntent::Perceptual {
-                return Err(Error::InvalidRenderingIntent);
+                return Err(at!(Error::InvalidRenderingIntent));
             }
             return Ok(Self::XYB { rendering_intent });
         }
@@ -477,7 +478,7 @@ impl JxlColorEncoding {
                 TransferFunction::DCI => JxlTransferFunction::DCI,
                 TransferFunction::HLG => JxlTransferFunction::HLG,
                 TransferFunction::Unknown => {
-                    return Err(Error::InvalidColorEncoding);
+                    return Err(at!(Error::InvalidColorEncoding));
                 }
             }
         };
@@ -517,7 +518,7 @@ impl JxlColorEncoding {
                 transfer_function,
                 rendering_intent,
             }),
-            ColorSpace::Unknown => Err(Error::InvalidColorSpace),
+            ColorSpace::Unknown => Err(at!(Error::InvalidColorSpace)),
         }
     }
 

--- a/zenjxl-decoder/src/api/convenience.rs
+++ b/zenjxl-decoder/src/api/convenience.rs
@@ -26,6 +26,7 @@ use super::{
     GainMapBundle, JxlBasicInfo, JxlColorProfile, JxlColorType, JxlDataFormat, JxlDecoder,
     JxlDecoderLimits, JxlDecoderOptions, JxlOutputBuffer, JxlPixelFormat, ProcessingResult, states,
 };
+use whereat::at;
 use crate::error::{Error, Result};
 use crate::headers::extra_channels::ExtraChannel;
 use crate::image::{OwnedRawImage, Rect};
@@ -117,7 +118,7 @@ pub fn decode_with(data: &[u8], options: JxlDecoderOptions) -> Result<JxlImage> 
     let mut decoder = match decoder.process(&mut input)? {
         ProcessingResult::Complete { result } => result,
         ProcessingResult::NeedsMoreInput { .. } => {
-            return Err(Error::OutOfBounds(0));
+            return Err(at!(Error::OutOfBounds(0)));
         }
     };
 
@@ -170,7 +171,7 @@ pub fn decode_with(data: &[u8], options: JxlDecoderOptions) -> Result<JxlImage> 
     let decoder = match decoder.process(&mut input)? {
         ProcessingResult::Complete { result } => result,
         ProcessingResult::NeedsMoreInput { .. } => {
-            return Err(Error::OutOfBounds(0));
+            return Err(at!(Error::OutOfBounds(0)));
         }
     };
 
@@ -199,7 +200,7 @@ pub fn decode_with(data: &[u8], options: JxlDecoderOptions) -> Result<JxlImage> 
     let mut decoder = match decoder.process(&mut input, &mut bufs)? {
         ProcessingResult::Complete { result } => result,
         ProcessingResult::NeedsMoreInput { .. } => {
-            return Err(Error::OutOfBounds(0));
+            return Err(at!(Error::OutOfBounds(0)));
         }
     };
 
@@ -417,7 +418,7 @@ pub fn read_header_with(data: &[u8], limits: JxlDecoderLimits) -> Result<JxlImag
     let decoder = match decoder.process(&mut input)? {
         ProcessingResult::Complete { result } => result,
         ProcessingResult::NeedsMoreInput { .. } => {
-            return Err(Error::OutOfBounds(0));
+            return Err(at!(Error::OutOfBounds(0)));
         }
     };
 

--- a/zenjxl-decoder/src/api/decoder.rs
+++ b/zenjxl-decoder/src/api/decoder.rs
@@ -14,6 +14,8 @@ use crate::{
     container::{frame_index::FrameIndexBox, gain_map::GainMapBundle},
     error::Result,
 };
+#[cfg(test)]
+use whereat::at;
 use states::*;
 use std::marker::PhantomData;
 
@@ -383,8 +385,8 @@ pub(crate) mod tests {
         chunk_size: usize,
         use_simple_pipeline: bool,
         do_flush: bool,
-        callback: Option<Box<dyn FnMut(&Frame, usize) -> Result<(), Error>>>,
-    ) -> Result<(usize, Vec<Vec<Image<f32>>>), Error> {
+        callback: Option<Box<dyn FnMut(&Frame, usize) -> Result<()>>>,
+    ) -> Result<(usize, Vec<Vec<Image<f32>>>)> {
         let mut options = JxlDecoderOptions::default();
         // Correctness tests should not be constrained by memory limits.
         // OOM/limit tests verify those separately.
@@ -519,15 +521,15 @@ pub(crate) mod tests {
         }
     }
 
-    fn decode_test_file(path: &Path) -> Result<(), Error> {
-        decode(&std::fs::read(path)?, usize::MAX, false, false, None)?;
+    fn decode_test_file(path: &Path) -> Result<()> {
+        decode(&std::fs::read(path).map_err(|e| at!(Error::from(e)))?, usize::MAX, false, false, None)?;
         Ok(())
     }
 
     for_each_test_file!(decode_test_file);
 
-    fn decode_test_file_chunks(path: &Path) -> Result<(), Error> {
-        decode(&std::fs::read(path)?, 1, false, false, None)?;
+    fn decode_test_file_chunks(path: &Path) -> Result<()> {
+        decode(&std::fs::read(path).map_err(|e| at!(Error::from(e)))?, 1, false, false, None)?;
         Ok(())
     }
 
@@ -539,7 +541,7 @@ pub(crate) mod tests {
         fc: usize,
         f: &[Image<f32>],
         sf: &[Image<f32>],
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         assert_eq!(
             f.len(),
             sf.len(),
@@ -590,8 +592,8 @@ pub(crate) mod tests {
             .collect()
     }
 
-    fn compare_pipelines(path: &Path) -> Result<(), Error> {
-        let file = std::fs::read(path)?;
+    fn compare_pipelines(path: &Path) -> Result<()> {
+        let file = std::fs::read(path).map_err(|e| at!(Error::from(e)))?;
         let reference_frames = decode(&file, usize::MAX, true, false, None)?.1;
         // Hash and drop reference pixels before second decode to halve peak
         // memory. Critical for 32-bit targets where two full 4K decoded
@@ -611,7 +613,7 @@ pub(crate) mod tests {
 
     for_each_test_file!(compare_pipelines);
 
-    fn compare_incremental(path: &Path) -> Result<(), Error> {
+    fn compare_incremental(path: &Path) -> Result<()> {
         let file = std::fs::read(path).unwrap();
         // One-shot decode — hash and drop before incremental decode.
         let (_, one_shot_frames) = decode(&file, usize::MAX, false, false, None)?;
@@ -1662,7 +1664,7 @@ pub(crate) mod tests {
             Err(err) => {
                 assert!(
                     matches!(
-                        err,
+                        err.error(),
                         Error::LimitExceeded {
                             resource: "pixels",
                             ..
@@ -1780,8 +1782,12 @@ pub(crate) mod tests {
         stop.cancel();
         assert!(stop.should_stop());
         // Verify it integrates with our error type
-        let result: crate::error::Result<()> = stop.check().map_err(Into::into);
-        assert!(matches!(result, Err(crate::error::Error::Cancelled)));
+        let result: crate::error::Result<()> =
+            stop.check().map_err(|e| at!(crate::error::Error::from(e)));
+        assert!(matches!(
+            result,
+            Err(e) if matches!(e.error(), crate::error::Error::Cancelled)
+        ));
     }
 
     /// Regression for the preview-frame recovery option-propagation bug that

--- a/zenjxl-decoder/src/api/inner/box_parser.rs
+++ b/zenjxl-decoder/src/api/inner/box_parser.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use std::io::IoSliceMut;
+use whereat::at;
 
 use crate::container::frame_index::FrameIndexBox;
 use crate::container::gain_map::GainMapBundle;
@@ -93,7 +94,7 @@ impl BoxParser {
                 ParseState::SignatureNeeded => {
                     self.box_buffer.refill(|b| input.read(b), None)?;
                     match check_signature_internal(&self.box_buffer)? {
-                        None => return Err(Error::InvalidSignature),
+                        None => return Err(at!(Error::InvalidSignature)),
                         Some(JxlSignatureType::Codestream) => {
                             self.state = ParseState::CodestreamBox(u64::MAX);
                             return Ok(u64::MAX);
@@ -113,10 +114,10 @@ impl BoxParser {
                     let skipped = if !self.box_buffer.is_empty() {
                         self.box_buffer.consume(num)
                     } else {
-                        input.skip(num)?
+                        input.skip(num).map_err(|e| at!(Error::from(e)))?
                     };
                     if skipped == 0 {
-                        return Err(Error::OutOfBounds(num));
+                        return Err(at!(Error::OutOfBounds(num)));
                     }
                     s -= skipped as u64;
                     if s == 0 {
@@ -165,9 +166,9 @@ impl BoxParser {
                     } else {
                         let old_len = buf.len();
                         buf.resize(old_len + num, 0);
-                        let read = input.read(&mut [IoSliceMut::new(&mut buf[old_len..])])?;
+                        let read = input.read(&mut [IoSliceMut::new(&mut buf[old_len..])]).map_err(|e| at!(Error::from(e)))?;
                         if read == 0 {
-                            return Err(Error::OutOfBounds(num));
+                            return Err(at!(Error::OutOfBounds(num)));
                         }
                         buf.truncate(old_len + read);
                         remaining -= read as u64;
@@ -190,9 +191,9 @@ impl BoxParser {
                     } else {
                         let old_len = buf.len();
                         buf.resize(old_len + num, 0);
-                        let read = input.read(&mut [IoSliceMut::new(&mut buf[old_len..])])?;
+                        let read = input.read(&mut [IoSliceMut::new(&mut buf[old_len..])]).map_err(|e| at!(Error::from(e)))?;
                         if read == 0 {
-                            return Err(Error::OutOfBounds(num));
+                            return Err(at!(Error::OutOfBounds(num)));
                         }
                         buf.truncate(old_len + read);
                         remaining -= read as u64;
@@ -215,9 +216,9 @@ impl BoxParser {
                     } else {
                         let old_len = buf.len();
                         buf.resize(old_len + num, 0);
-                        let read = input.read(&mut [IoSliceMut::new(&mut buf[old_len..])])?;
+                        let read = input.read(&mut [IoSliceMut::new(&mut buf[old_len..])]).map_err(|e| at!(Error::from(e)))?;
                         if read == 0 {
-                            return Err(Error::OutOfBounds(num));
+                            return Err(at!(Error::OutOfBounds(num)));
                         }
                         buf.truncate(old_len + read);
                         remaining -= read as u64;
@@ -243,9 +244,9 @@ impl BoxParser {
                     } else {
                         let old_len = buf.len();
                         buf.resize(old_len + num, 0);
-                        let read = input.read(&mut [IoSliceMut::new(&mut buf[old_len..])])?;
+                        let read = input.read(&mut [IoSliceMut::new(&mut buf[old_len..])]).map_err(|e| at!(Error::from(e)))?;
                         if read == 0 {
-                            return Err(Error::OutOfBounds(num));
+                            return Err(at!(Error::OutOfBounds(num)));
                         }
                         buf.truncate(old_len + read);
                         remaining -= read as u64;
@@ -300,14 +301,14 @@ impl BoxParser {
                         _ => 8,
                     };
                     if self.box_buffer.len() <= min_len {
-                        return Err(Error::OutOfBounds(min_len - self.box_buffer.len()));
+                        return Err(at!(Error::OutOfBounds(min_len - self.box_buffer.len())));
                     }
                     let ty: [_; 4] = self.box_buffer[4..8].try_into().unwrap();
                     let extra_len = if &ty == b"jxlp" { 4 } else { 0 };
                     if self.box_buffer.len() <= min_len + extra_len {
-                        return Err(Error::OutOfBounds(
+                        return Err(at!(Error::OutOfBounds(
                             min_len + extra_len - self.box_buffer.len(),
-                        ));
+                        )));
                     }
                     let box_len = match &self.box_buffer[..] {
                         [0, 0, 0, 1, ..] => {
@@ -320,7 +321,7 @@ impl BoxParser {
                         u64::MAX
                     } else {
                         if box_len <= (min_len + extra_len) as u64 {
-                            return Err(Error::InvalidBox);
+                            return Err(at!(Error::InvalidBox));
                         }
                         box_len - min_len as u64 - extra_len as u64
                     };
@@ -330,7 +331,7 @@ impl BoxParser {
                                 self.box_type,
                                 CodestreamBoxType::Jxlp(..) | CodestreamBoxType::LastJxlp
                             ) {
-                                return Err(Error::InvalidBox);
+                                return Err(at!(Error::InvalidBox));
                             }
                             self.box_type = CodestreamBoxType::Jxlc;
                             self.state = ParseState::CodestreamBox(content_len);
@@ -341,7 +342,7 @@ impl BoxParser {
                             );
                             let wanted_idx = match self.box_type {
                                 CodestreamBoxType::Jxlc | CodestreamBoxType::LastJxlp => {
-                                    return Err(Error::InvalidBox);
+                                    return Err(at!(Error::InvalidBox));
                                 }
                                 CodestreamBoxType::None => 0,
                                 CodestreamBoxType::Jxlp(i) => i + 1,
@@ -349,7 +350,7 @@ impl BoxParser {
                             let last = index & 0x80000000 != 0;
                             let idx = index & 0x7fffffff;
                             if idx != wanted_idx {
-                                return Err(Error::InvalidBox);
+                                return Err(at!(Error::InvalidBox));
                             }
                             self.box_type = if last {
                                 CodestreamBoxType::LastJxlp
@@ -364,7 +365,7 @@ impl BoxParser {
                         }
                         b"jhgm" => {
                             if content_len == u64::MAX {
-                                return Err(Error::InvalidBox);
+                                return Err(at!(Error::InvalidBox));
                             }
                             // Reasonable size limit for a gain map bundle (256 MB).
                             // Gain maps contain a full JXL codestream so they can be large.
@@ -377,13 +378,13 @@ impl BoxParser {
                                 // error, never an `abort()` on the parser thread.
                                 self.state = ParseState::BufferingGainMap(
                                     content_len,
-                                    Vec::<u8>::new_with_capacity(content_len as usize)?,
+                                    Vec::<u8>::new_with_capacity(content_len as usize).map_err(|e| at!(Error::from(e)))?,
                                 );
                             }
                         }
                         b"jxli" => {
                             if content_len == u64::MAX {
-                                return Err(Error::InvalidBox);
+                                return Err(at!(Error::InvalidBox));
                             }
                             // Reasonable size limit for a frame index box (16 MB).
                             if content_len > 16 * 1024 * 1024 {
@@ -391,13 +392,13 @@ impl BoxParser {
                             } else {
                                 self.state = ParseState::BufferingFrameIndex(
                                     content_len,
-                                    Vec::<u8>::new_with_capacity(content_len as usize)?,
+                                    Vec::<u8>::new_with_capacity(content_len as usize).map_err(|e| at!(Error::from(e)))?,
                                 );
                             }
                         }
                         b"Exif" => {
                             if content_len == u64::MAX {
-                                return Err(Error::InvalidBox);
+                                return Err(at!(Error::InvalidBox));
                             }
                             // Reasonable size limit for EXIF data (16 MB).
                             if content_len > 16 * 1024 * 1024 {
@@ -405,13 +406,13 @@ impl BoxParser {
                             } else {
                                 self.state = ParseState::BufferingExif(
                                     content_len,
-                                    Vec::<u8>::new_with_capacity(content_len as usize)?,
+                                    Vec::<u8>::new_with_capacity(content_len as usize).map_err(|e| at!(Error::from(e)))?,
                                 );
                             }
                         }
                         b"xml " => {
                             if content_len == u64::MAX {
-                                return Err(Error::InvalidBox);
+                                return Err(at!(Error::InvalidBox));
                             }
                             // Reasonable size limit for XMP data (16 MB).
                             if content_len > 16 * 1024 * 1024 {
@@ -419,7 +420,7 @@ impl BoxParser {
                             } else {
                                 self.state = ParseState::BufferingXmp(
                                     content_len,
-                                    Vec::<u8>::new_with_capacity(content_len as usize)?,
+                                    Vec::<u8>::new_with_capacity(content_len as usize).map_err(|e| at!(Error::from(e)))?,
                                 );
                             }
                         }

--- a/zenjxl-decoder/src/api/inner/codestream_parser/mod.rs
+++ b/zenjxl-decoder/src/api/inner/codestream_parser/mod.rs
@@ -7,6 +7,7 @@ use std::{
     collections::{HashSet, VecDeque},
     io::IoSliceMut,
 };
+use whereat::at;
 
 use sections::SectionState;
 
@@ -196,7 +197,7 @@ impl CodestreamParser {
                 .filter(|x| x.is_some())
                 .count();
             if output_buffers.len() != expected_len {
-                return Err(Error::WrongBufferCount(output_buffers.len(), expected_len));
+                return Err(at!(Error::WrongBufferCount(output_buffers.len(), expected_len)));
             }
         }
         // If we have sections to read, read into sections; otherwise, read into the local buffer.
@@ -228,7 +229,7 @@ impl CodestreamParser {
                 if !self.skip_sections {
                     // This is just an estimate as there could be box bytes in the middle.
                     let mut readable_section_data = (self.non_section_buf.len()
-                        + input.available_bytes()?
+                        + input.available_bytes().map_err(|e| at!(Error::from(e)))?
                         + self.ready_section_data)
                         .max(1);
                     // Ensure enough section buffers are available for reading available data.
@@ -245,7 +246,7 @@ impl CodestreamParser {
                     }
                     // Read sections up to the end of the current box.
                     let mut available_codestream = match box_parser.get_more_codestream(input) {
-                        Err(Error::OutOfBounds(_)) => 0,
+                        Err(e) if matches!(e.error(), Error::OutOfBounds(_)) => 0,
                         Ok(c) => c as usize,
                         Err(e) => return Err(e),
                     };
@@ -273,7 +274,7 @@ impl CodestreamParser {
                         let num = if !box_parser.box_buffer.is_empty() {
                             box_parser.box_buffer.take(buffers)
                         } else {
-                            input.read(buffers)?
+                            input.read(buffers).map_err(|e| at!(Error::from(e)))?
                         };
                         self.ready_section_data += num;
                         box_parser.consume_codestream(num as u64);
@@ -284,8 +285,10 @@ impl CodestreamParser {
                     }
                     match self.process_sections(decode_options, &mut output_buffers, do_flush) {
                         Ok(None) => Ok(()),
-                        Ok(Some(missing)) => Err(Error::OutOfBounds(missing)),
-                        Err(Error::OutOfBounds(_)) => Err(Error::SectionTooShort),
+                        Ok(Some(missing)) => Err(at!(Error::OutOfBounds(missing))),
+                        Err(e) if matches!(e.error(), Error::OutOfBounds(_)) => {
+                            Err(at!(Error::SectionTooShort))
+                        }
                         Err(err) => Err(err),
                     }?;
                     // If no section data was read and sections are still pending,
@@ -297,9 +300,9 @@ impl CodestreamParser {
                         && box_parser.box_buffer.is_empty()
                     {
                         let total_needed: usize = self.sections.iter().map(|s| s.len).sum();
-                        return Err(Error::OutOfBounds(
+                        return Err(at!(Error::OutOfBounds(
                             total_needed.saturating_sub(self.ready_section_data),
-                        ));
+                        )));
                     }
                 } else {
                     let total_size = self.sections.iter().map(|x| x.len).sum::<usize>();
@@ -313,7 +316,7 @@ impl CodestreamParser {
                         let skipped = if !box_parser.box_buffer.is_empty() {
                             box_parser.box_buffer.consume(to_skip)
                         } else {
-                            input.skip(to_skip)?
+                            input.skip(to_skip).map_err(|e| at!(Error::from(e)))?
                         };
                         box_parser.consume_codestream(skipped as u64);
                         self.ready_section_data += skipped;
@@ -322,7 +325,7 @@ impl CodestreamParser {
                         }
                     }
                     if self.ready_section_data < total_size {
-                        return Err(Error::OutOfBounds(total_size - self.ready_section_data));
+                        return Err(at!(Error::OutOfBounds(total_size - self.ready_section_data)));
                     } else {
                         self.sections.clear();
                         // Finalize the skipped frame, mirroring what process_sections does
@@ -385,7 +388,8 @@ impl CodestreamParser {
                     // parsing resumes if `process` is called again with more
                     // input.
                     match box_parser.get_more_codestream(input) {
-                        Ok(_) | Err(Error::OutOfBounds(_)) => {}
+                        Ok(_) => {}
+                        Err(e) if matches!(e.error(), Error::OutOfBounds(_)) => {}
                         Err(e) => return Err(e),
                     }
                     return Ok(());
@@ -395,7 +399,7 @@ impl CodestreamParser {
                 // multiple buffer refills to complete.
                 loop {
                     let available_codestream = match box_parser.get_more_codestream(input) {
-                        Err(Error::OutOfBounds(_)) => 0,
+                        Err(e) if matches!(e.error(), Error::OutOfBounds(_)) => 0,
                         Ok(c) => c as usize,
                         Err(e) => return Err(e),
                     };
@@ -423,7 +427,7 @@ impl CodestreamParser {
                             if input.available_bytes().unwrap_or(0) > 0 {
                                 continue;
                             } else {
-                                return Err(Error::OutOfBounds(*needed as usize));
+                                return Err(at!(Error::OutOfBounds(*needed as usize)));
                             }
                         }
                     }
@@ -434,7 +438,10 @@ impl CodestreamParser {
                             self.header_needed_bytes = None;
                             break;
                         }
-                        Err(Error::OutOfBounds(n)) => {
+                        Err(e) if matches!(e.error(), Error::OutOfBounds(_)) => {
+                            let &Error::OutOfBounds(n) = e.error() else {
+                                unreachable!()
+                            };
                             let new_range = self.non_section_buf.range();
                             // If non-section parsing consumed no bytes, and the non-section buffer
                             // cannot accept more bytes, enlarge the buffer to allow to make progress.
@@ -446,7 +453,7 @@ impl CodestreamParser {
                             if input.available_bytes().unwrap_or(0) > 0 {
                                 continue;
                             } else {
-                                return Err(Error::OutOfBounds(n));
+                                return Err(at!(Error::OutOfBounds(n)));
                             }
                         }
                         Err(e) => return Err(e),

--- a/zenjxl-decoder/src/api/inner/codestream_parser/non_section.rs
+++ b/zenjxl-decoder/src/api/inner/codestream_parser/non_section.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use std::io::IoSliceMut;
+use whereat::at;
 use std::sync::Arc;
 
 use super::SECTION_PADDING;
@@ -85,21 +86,21 @@ fn check_size_limit(
     if let Some(limit) = limits.max_pixels
         && total_pixels > limit
     {
-        return Err(Error::LimitExceeded {
+        return Err(at!(Error::LimitExceeded {
             resource: "pixels",
             actual: total_pixels as u64,
             limit: limit as u64,
-        });
+        }));
     }
     // Check extra channels limit
     if let Some(limit) = limits.max_extra_channels
         && num_ec > limit
     {
-        return Err(Error::LimitExceeded {
+        return Err(at!(Error::LimitExceeded {
             resource: "extra_channels",
             actual: num_ec as u64,
             limit: limit as u64,
-        });
+        }));
     }
     Ok(())
 }
@@ -225,11 +226,14 @@ impl CodestreamParser {
                 for _ in 0..icc_parser.remaining() {
                     match icc_parser.read_one(&mut br) {
                         Ok(()) => bits = br.total_bits_read(),
-                        Err(Error::OutOfBounds(c)) => {
+                        Err(e) if matches!(e.error(), Error::OutOfBounds(_)) => {
+                            let &Error::OutOfBounds(c) = e.error() else {
+                                unreachable!()
+                            };
                             self.non_section_buf.consume(bits / 8);
                             self.non_section_bit_offset = (bits % 8) as u8;
                             // Estimate >= one bit per remaining character to read.
-                            return Err(Error::OutOfBounds(c + icc_parser.remaining() / 8));
+                            return Err(at!(Error::OutOfBounds(c + icc_parser.remaining() / 8)));
                         }
                         Err(e) => return Err(e),
                     }
@@ -277,7 +281,7 @@ impl CodestreamParser {
                     && decode_options.cms.is_none()
                     && *user_profile != embedded_color_profile
                 {
-                    return Err(Error::NonXybOutputNoCMS);
+                    return Err(at!(Error::NonXybOutputNoCMS));
                 }
             } else {
                 self.update_default_output_color_profile();
@@ -342,7 +346,7 @@ impl CodestreamParser {
                         .as_ref()
                         .is_some_and(|info| info.preview_size.is_some());
                 if !is_preview_frame && frame_is_progressive(&frame_header) {
-                    return Err(Error::ProgressiveRejected);
+                    return Err(at!(Error::ProgressiveRejected));
                 }
             }
 
@@ -357,9 +361,9 @@ impl CodestreamParser {
             // fixes #770.)
             let num_groups = frame_header.num_groups();
             let num_passes = frame_header.passes.num_passes as usize;
-            let mut hf_sections = Vec::new_with_capacity(num_groups)?;
+            let mut hf_sections = Vec::new_with_capacity(num_groups).map_err(|e| at!(Error::from(e)))?;
             for _ in 0..num_groups {
-                let mut row = Vec::new_with_capacity(num_passes)?;
+                let mut row = Vec::new_with_capacity(num_passes).map_err(|e| at!(Error::from(e)))?;
                 for _ in 0..num_passes {
                     row.push(None);
                 }
@@ -387,13 +391,16 @@ impl CodestreamParser {
             while !toc_parser.is_complete() {
                 match toc_parser.read_step(&mut br) {
                     Ok(()) => bits = br.total_bits_read(),
-                    Err(Error::OutOfBounds(c)) => {
+                    Err(e) if matches!(e.error(), Error::OutOfBounds(_)) => {
+                        let &Error::OutOfBounds(c) = e.error() else {
+                            unreachable!()
+                        };
                         self.non_section_buf.consume(bits / 8);
                         self.non_section_bit_offset = (bits % 8) as u8;
                         // Estimate >= 16 bits per remaining entry to read.
-                        return Err(Error::OutOfBounds(
+                        return Err(at!(Error::OutOfBounds(
                             c + toc_parser.remaining_entries() as usize * 2,
-                        ));
+                        )));
                     }
                     Err(e) => return Err(e),
                 }
@@ -462,7 +469,7 @@ impl CodestreamParser {
                 break;
             }
             let mut data = Vec::new();
-            data.try_reserve_exact(buf.len + SECTION_PADDING)?;
+            data.try_reserve_exact(buf.len + SECTION_PADDING).map_err(|e| at!(Error::from(e)))?;
             data.resize(buf.len + SECTION_PADDING, 0);
             buf.data = data;
             self.ready_section_data += self

--- a/zenjxl-decoder/src/api/inner/mod.rs
+++ b/zenjxl-decoder/src/api/inner/mod.rs
@@ -5,6 +5,7 @@
 
 #[cfg(test)]
 use crate::api::FrameCallback;
+use whereat::at;
 use crate::{
     api::JxlFrameHeader,
     error::{Error, Result},
@@ -109,7 +110,7 @@ impl JxlDecoderInner {
     /// Same semantics as JxlDecoderSetOutputColorProfile.
     pub fn set_output_color_profile(&mut self, profile: JxlColorProfile) -> Result<()> {
         if let (JxlColorProfile::Icc(_), None) = (&profile, &self.options.cms) {
-            return Err(Error::ICCOutputNoCMS);
+            return Err(at!(Error::ICCOutputNoCMS));
         }
         self.codestream_parser.output_color_profile = Some(profile);
         self.codestream_parser.output_color_profile_set_by_user = true;

--- a/zenjxl-decoder/src/api/inner/process.rs
+++ b/zenjxl-decoder/src/api/inner/process.rs
@@ -7,6 +7,7 @@ use std::{
     io::IoSliceMut,
     ops::{Deref, Range},
 };
+use whereat::at;
 
 use crate::error::Result;
 
@@ -50,7 +51,7 @@ impl SmallBuffer {
             } else {
                 self.buf.len()
             };
-            let num = get_input(&mut [IoSliceMut::new(&mut self.buf[self.range.end..stop])])?;
+            let num = get_input(&mut [IoSliceMut::new(&mut self.buf[self.range.end..stop])]).map_err(|e| at!(crate::error::Error::from(e)))?;
             total += num;
             self.range.end += num;
             if num == 0 {
@@ -142,7 +143,7 @@ impl JxlDecoderInner {
             true,
         ) {
             Ok(()) => Ok(()),
-            Err(crate::error::Error::OutOfBounds(_)) => Ok(()),
+            Err(e) if matches!(e.error(), crate::error::Error::OutOfBounds(_)) => Ok(()),
             Err(e) => Err(e),
         }
     }

--- a/zenjxl-decoder/src/api/mod.rs
+++ b/zenjxl-decoder/src/api/mod.rs
@@ -70,15 +70,18 @@ pub enum ProcessingResult<T, U> {
 }
 
 impl<T> ProcessingResult<T, ()> {
-    fn new(
-        result: Result<T, crate::error::Error>,
-    ) -> Result<ProcessingResult<T, ()>, crate::error::Error> {
+    fn new(result: Result<T>) -> Result<ProcessingResult<T, ()>> {
         match result {
             Ok(v) => Ok(ProcessingResult::Complete { result: v }),
-            Err(crate::error::Error::OutOfBounds(v)) => Ok(ProcessingResult::NeedsMoreInput {
-                size_hint: v,
-                fallback: (),
-            }),
+            Err(e) if matches!(e.error(), crate::error::Error::OutOfBounds(_)) => {
+                let &crate::error::Error::OutOfBounds(v) = e.error() else {
+                    unreachable!()
+                };
+                Ok(ProcessingResult::NeedsMoreInput {
+                    size_hint: v,
+                    fallback: (),
+                })
+            }
             Err(e) => Err(e),
         }
     }

--- a/zenjxl-decoder/src/api/signature.rs
+++ b/zenjxl-decoder/src/api/signature.rs
@@ -7,6 +7,7 @@ use crate::{
     api::ProcessingResult,
     error::{Error, Result},
 };
+use whereat::at;
 
 /// The magic bytes for a bare JPEG XL codestream.
 pub(crate) const CODESTREAM_SIGNATURE: [u8; 2] = [0xff, 0x0a];
@@ -42,7 +43,7 @@ pub(crate) fn check_signature_internal(file_prefix: &[u8]) -> Result<Option<JxlS
             return if prefix_len >= len {
                 Ok(Some(st))
             } else {
-                Err(Error::OutOfBounds(len - prefix_len))
+                Err(at!(Error::OutOfBounds(len - prefix_len)))
             };
         }
     }

--- a/zenjxl-decoder/src/container/frame_index.rs
+++ b/zenjxl-decoder/src/container/frame_index.rs
@@ -11,6 +11,7 @@
 //! frame counts.
 
 use std::num::NonZero;
+use whereat::at;
 
 use byteorder::{BigEndian, ReadBytesExt};
 
@@ -74,7 +75,7 @@ impl FrameIndexBox {
 
         let nf = read_varint_from_reader(&mut reader)?;
         if nf > u32::MAX as u64 {
-            return Err(Error::InvalidBox);
+            return Err(at!(Error::InvalidBox));
         }
         let nf = nf as usize;
 
@@ -91,7 +92,7 @@ impl FrameIndexBox {
         // Each entry requires at least 3 bytes (three varints, min 1 byte each).
         // Cap the pre-allocation to avoid OOM from a crafted NF value.
         // Use new_with_capacity to return Err on allocation failure instead of aborting.
-        let mut entries = Vec::new_with_capacity(nf.min(reader.len() / 3))?;
+        let mut entries = Vec::new_with_capacity(nf.min(reader.len() / 3)).map_err(|e| at!(Error::from(e)))?;
         let mut absolute_offset: u64 = 0;
 
         for _ in 0..nf {

--- a/zenjxl-decoder/src/container/gain_map.rs
+++ b/zenjxl-decoder/src/container/gain_map.rs
@@ -14,6 +14,7 @@
 //! to parse (e.g., via ultrahdr-core).
 
 use crate::error::{Error, Result};
+use whereat::at;
 
 /// Current version of the gain map bundle format.
 const JHGM_VERSION: u8 = 0x00;
@@ -54,39 +55,39 @@ impl GainMapBundle {
 
         // --- version ---
         if data.is_empty() {
-            return Err(Error::InvalidGainMap("empty jhgm box".into()));
+            return Err(at!(Error::InvalidGainMap("empty jhgm box".into())));
         }
         let version = data[pos];
         pos += 1;
         if version != JHGM_VERSION {
-            return Err(Error::InvalidGainMap(format!(
+            return Err(at!(Error::InvalidGainMap(format!(
                 "unsupported jhgm version: {version:#04x}, expected {JHGM_VERSION:#04x}"
-            )));
+            ))));
         }
 
         // --- gain_map_metadata_size (u16 BE) ---
         if pos + 2 > data.len() {
-            return Err(Error::InvalidGainMap(
+            return Err(at!(Error::InvalidGainMap(
                 "truncated: missing metadata size".into(),
-            ));
+            )));
         }
         let metadata_size = u16::from_be_bytes([data[pos], data[pos + 1]]) as usize;
         pos += 2;
 
         if pos + metadata_size > data.len() {
-            return Err(Error::InvalidGainMap(format!(
+            return Err(at!(Error::InvalidGainMap(format!(
                 "truncated: metadata size {metadata_size} exceeds remaining {} bytes",
                 data.len() - pos
-            )));
+            ))));
         }
         let metadata = data[pos..pos + metadata_size].to_vec();
         pos += metadata_size;
 
         // --- color_encoding_size (u8) ---
         if pos >= data.len() {
-            return Err(Error::InvalidGainMap(
+            return Err(at!(Error::InvalidGainMap(
                 "truncated: missing color_encoding_size".into(),
-            ));
+            )));
         }
         let color_encoding_size = data[pos] as usize;
         pos += 1;
@@ -95,10 +96,10 @@ impl GainMapBundle {
             None
         } else {
             if pos + color_encoding_size > data.len() {
-                return Err(Error::InvalidGainMap(format!(
+                return Err(at!(Error::InvalidGainMap(format!(
                     "truncated: color_encoding size {color_encoding_size} exceeds remaining {} bytes",
                     data.len() - pos
-                )));
+                ))));
             }
             let ce = data[pos..pos + color_encoding_size].to_vec();
             pos += color_encoding_size;
@@ -107,9 +108,9 @@ impl GainMapBundle {
 
         // --- alt_icc_size (u32 BE) ---
         if pos + 4 > data.len() {
-            return Err(Error::InvalidGainMap(
+            return Err(at!(Error::InvalidGainMap(
                 "truncated: missing alt_icc_size".into(),
-            ));
+            )));
         }
         let alt_icc_size =
             u32::from_be_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]) as usize;
@@ -119,10 +120,10 @@ impl GainMapBundle {
             None
         } else {
             if pos + alt_icc_size > data.len() {
-                return Err(Error::InvalidGainMap(format!(
+                return Err(at!(Error::InvalidGainMap(format!(
                     "truncated: alt_icc size {alt_icc_size} exceeds remaining {} bytes",
                     data.len() - pos
-                )));
+                ))));
             }
             let icc = data[pos..pos + alt_icc_size].to_vec();
             pos += alt_icc_size;

--- a/zenjxl-decoder/src/container/parse.rs
+++ b/zenjxl-decoder/src/container/parse.rs
@@ -6,6 +6,7 @@
 // Originally written for jxl-oxide.
 
 use super::{BitstreamKind, ContainerParser, DetectState, JxlpIndexState, box_header::*};
+use whereat::at;
 use crate::{
     api::{CODESTREAM_SIGNATURE, CONTAINER_SIGNATURE},
     error::{Error, Result},
@@ -83,11 +84,11 @@ impl<'inner, 'buf> ParseEvents<'inner, 'buf> {
                                 }
                                 JxlpIndexState::SingleJxlc => {
                                     warn!("Duplicate jxlc box found");
-                                    return Err(Error::InvalidBox);
+                                    return Err(at!(Error::InvalidBox));
                                 }
                                 JxlpIndexState::Jxlp(_) | JxlpIndexState::JxlpFinished => {
                                     warn!("Found jxlc box instead of jxlp box");
-                                    return Err(Error::InvalidBox);
+                                    return Err(at!(Error::InvalidBox));
                                 }
                             }
 
@@ -99,7 +100,7 @@ impl<'inner, 'buf> ParseEvents<'inner, 'buf> {
                             if let Some(box_size) = header.box_size()
                                 && box_size < 4
                             {
-                                return Err(Error::InvalidBox);
+                                return Err(at!(Error::InvalidBox));
                             }
 
                             match jxlp_index_state {
@@ -111,11 +112,11 @@ impl<'inner, 'buf> ParseEvents<'inner, 'buf> {
                                 }
                                 JxlpIndexState::SingleJxlc => {
                                     warn!("jxlp box found after jxlc box");
-                                    return Err(Error::InvalidBox);
+                                    return Err(at!(Error::InvalidBox));
                                 }
                                 JxlpIndexState::JxlpFinished => {
                                     warn!("found another jxlp box after the final one");
-                                    return Err(Error::InvalidBox);
+                                    return Err(at!(Error::InvalidBox));
                                 }
                             }
 
@@ -150,7 +151,7 @@ impl<'inner, 'buf> ParseEvents<'inner, 'buf> {
                                 actual_index = index,
                                 "Out-of-order jxlp box found",
                             );
-                            return Err(Error::InvalidBox);
+                            return Err(at!(Error::InvalidBox));
                         }
                         state => {
                             unreachable!("invalid jxlp index state in WaitingJxlpIndex: {state:?}");

--- a/zenjxl-decoder/src/entropy_coding/ans.rs
+++ b/zenjxl-decoder/src/entropy_coding/ans.rs
@@ -6,6 +6,7 @@
 // Originally written for jxl-oxide.
 
 use crate::bit_reader::BitReader;
+use whereat::at;
 use crate::error::{Error, Result};
 
 const LOG_SUM_PROBS: usize = 12;
@@ -45,12 +46,12 @@ impl AnsHistogram {
         let v0 = Self::read_u8(br)? as usize;
         let v1 = Self::read_u8(br)? as usize;
         if v0 == v1 {
-            return Err(Error::InvalidAnsHistogram);
+            return Err(at!(Error::InvalidAnsHistogram));
         }
 
         let alphabet_size = v0.max(v1) + 1;
         if alphabet_size > table_size {
-            return Err(Error::InvalidAnsHistogram);
+            return Err(at!(Error::InvalidAnsHistogram));
         }
 
         let prob = br.read(LOG_SUM_PROBS)? as u16;
@@ -66,7 +67,7 @@ impl AnsHistogram {
         let val = Self::read_u8(br)? as usize;
         let alphabet_size = val + 1;
         if alphabet_size > table_size {
-            return Err(Error::InvalidAnsHistogram);
+            return Err(at!(Error::InvalidAnsHistogram));
         }
 
         dist[val] = SUM_PROBS;
@@ -79,7 +80,7 @@ impl AnsHistogram {
 
         let alphabet_size = Self::read_u8(br)? as usize + 1;
         if alphabet_size > table_size {
-            return Err(Error::InvalidAnsHistogram);
+            return Err(at!(Error::InvalidAnsHistogram));
         }
 
         let base = SUM_PROBS as usize / alphabet_size;
@@ -104,12 +105,12 @@ impl AnsHistogram {
 
         let shift = (br.read(len)? + (1 << len) - 1) as i16;
         if shift > 13 {
-            return Err(Error::InvalidAnsHistogram);
+            return Err(at!(Error::InvalidAnsHistogram));
         }
 
         let alphabet_size = Self::read_u8(br)? as usize + 3;
         if alphabet_size > table_size {
-            return Err(Error::InvalidAnsHistogram);
+            return Err(at!(Error::InvalidAnsHistogram));
         }
 
         // TODO(tirr-c): This could be an array of length `SUM_PROB / 4` (4 is from the minimum
@@ -122,7 +123,7 @@ impl AnsHistogram {
             if dist[idx] == RLE_MARKER_SYM {
                 let repeat_count = Self::read_u8(br)? as usize + 4;
                 if idx + repeat_count > alphabet_size {
-                    return Err(Error::InvalidAnsHistogram);
+                    return Err(at!(Error::InvalidAnsHistogram));
                 }
                 repeat_ranges.push(idx..(idx + repeat_count));
                 idx += repeat_count;
@@ -142,10 +143,10 @@ impl AnsHistogram {
             idx += 1;
         }
         let Some((_, omit_pos)) = omit_data else {
-            return Err(Error::InvalidAnsHistogram);
+            return Err(at!(Error::InvalidAnsHistogram));
         };
         if dist.get(omit_pos + 1) == Some(&RLE_MARKER_SYM) {
-            return Err(Error::InvalidAnsHistogram);
+            return Err(at!(Error::InvalidAnsHistogram));
         }
 
         let mut repeat_range_idx = 0usize;
@@ -162,7 +163,7 @@ impl AnsHistogram {
                     acc += *code;
                     // dist[omit_pos] > 0
                     if acc >= SUM_PROBS {
-                        return Err(Error::InvalidAnsHistogram);
+                        return Err(at!(Error::InvalidAnsHistogram));
                     }
                     continue;
                 }
@@ -186,7 +187,7 @@ impl AnsHistogram {
             acc += *code;
             // dist[omit_pos] > 0
             if acc >= SUM_PROBS {
-                return Err(Error::InvalidAnsHistogram);
+                return Err(at!(Error::InvalidAnsHistogram));
             }
         }
         dist[omit_pos] = SUM_PROBS - acc;
@@ -243,7 +244,7 @@ impl AnsHistogram {
         // If `dist` sums to `SUM_PROB`, overfull and underfull must both be empty here.
         // A crafted bitstream could violate this invariant, so return an error instead of panicking.
         if !overfull.is_empty() || !underfull.is_empty() {
-            return Err(Error::InvalidAnsHistogram);
+            return Err(at!(Error::InvalidAnsHistogram));
         }
 
         Ok(buckets
@@ -310,7 +311,7 @@ impl AnsHistogram {
 
         let expected_len = 1 << (LOG_SUM_PROBS - log_bucket_size);
         if buckets.len() != expected_len {
-            return Err(Error::InvalidAnsHistogram);
+            return Err(at!(Error::InvalidAnsHistogram));
         }
         // Safety note: log_bucket_size <= LOG_SUM_PROBS by construction, and we
         // just checked that buckets.len() = 2^(LOG_SUM_PROBS - log_bucket_size)
@@ -439,7 +440,7 @@ impl AnsReader {
         if self.0 == Self::CHECKSUM {
             Ok(())
         } else {
-            Err(Error::AnsChecksumMismatch)
+            Err(at!(Error::AnsChecksumMismatch))
         }
     }
 
@@ -492,7 +493,7 @@ mod test {
             loop {
                 match AnsHistogram::decode(&mut br, 8) {
                     Ok(histogram) => validate_buckets(&histogram.buckets),
-                    Err(Error::OutOfBounds(_)) => break,
+                    Err(e) if matches!(e.error(), Error::OutOfBounds(_)) => break,
                     Err(_) => {}
                 }
             }

--- a/zenjxl-decoder/src/entropy_coding/context_map.rs
+++ b/zenjxl-decoder/src/entropy_coding/context_map.rs
@@ -4,7 +4,8 @@
 // license that can be found in the LICENSE file.
 
 use crate::bit_reader::BitReader;
-use crate::error::Error;
+use whereat::at;
+use crate::error::{Error, Result};
 use crate::util::TryVecExt;
 use std::collections::HashSet;
 
@@ -41,7 +42,7 @@ fn verify_context_map(ctx_map: &[u8]) -> Result<(), Error> {
     Ok(())
 }
 
-pub fn decode_context_map(num_contexts: usize, br: &mut BitReader) -> Result<Vec<u8>, Error> {
+pub fn decode_context_map(num_contexts: usize, br: &mut BitReader) -> Result<Vec<u8>> {
     let is_simple = br.read(1)? != 0;
     if is_simple {
         let bits_per_entry = br.read(2)? as usize;
@@ -50,7 +51,7 @@ pub fn decode_context_map(num_contexts: usize, br: &mut BitReader) -> Result<Vec
                 .map(|_| Ok(br.read(bits_per_entry)? as u8))
                 .collect()
         } else {
-            Ok(Vec::try_from_elem(0u8, num_contexts)?)
+            Ok(Vec::try_from_elem(0u8, num_contexts).map_err(|e| at!(Error::from(e)))?)
         }
     } else {
         let use_mtf = br.read(1)? != 0;

--- a/zenjxl-decoder/src/entropy_coding/decode.rs
+++ b/zenjxl-decoder/src/entropy_coding/decode.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use jxl_macros::UnconditionalCoder;
+use whereat::at;
 
 use crate::bit_reader::BitReader;
 use crate::entropy_coding::ans::*;
@@ -218,11 +219,11 @@ impl ErrorState {
 
     fn check_for_error(&self) -> Result<()> {
         if self.lz77_repeat {
-            Err(Error::UnexpectedLz77Repeat)
+            Err(at!(Error::UnexpectedLz77Repeat))
         } else if self.arithmetic_overflow {
-            Err(Error::ArithmeticOverflow)
+            Err(at!(Error::ArithmeticOverflow))
         } else if self.nbits_acc >= 32 {
-            Err(Error::IntegerTooLarge(32))
+            Err(at!(Error::IntegerTooLarge(32)))
         } else {
             Ok(())
         }
@@ -276,7 +277,7 @@ impl SymbolReader {
                     min_symbol,
                     min_length,
                     dist_multiplier,
-                    window: Vec::new_with_capacity(1 << Lz77State::LOG_WINDOW_SIZE)?,
+                    window: Vec::new_with_capacity(1 << Lz77State::LOG_WINDOW_SIZE).map_err(|e| at!(Error::from(e)))?,
                     num_to_copy: 0,
                     copy_pos: 0,
                     num_decoded: 0,
@@ -600,7 +601,7 @@ impl Histograms {
     pub fn decode(num_contexts: usize, br: &mut BitReader, allow_lz77: bool) -> Result<Histograms> {
         let lz77_params = Lz77Params::read_unconditional(&(), br, &Empty {})?;
         if !allow_lz77 && lz77_params.enabled {
-            return Err(Error::Lz77Disallowed);
+            return Err(at!(Error::Lz77Disallowed));
         }
         let (num_contexts, lz77_length_uint) = if lz77_params.enabled {
             (
@@ -635,7 +636,7 @@ impl Histograms {
         };
         let num_histograms = *context_map.iter().max().unwrap() + 1;
         let uint_configs = ((0..num_histograms).map(|_| HybridUint::decode(log_alpha_size, br)))
-            .collect::<Result<_>>()?;
+            .collect::<Result<_, Error>>()?;
 
         let codes = if use_prefix_code {
             Codes::Huffman(HuffmanCodes::decode(num_histograms as usize, br)?)

--- a/zenjxl-decoder/src/entropy_coding/huffman.rs
+++ b/zenjxl-decoder/src/entropy_coding/huffman.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use std::fmt::Debug;
+use whereat::at;
 
 use crate::bit_reader::BitReader;
 use crate::entropy_coding::decode::*;
@@ -77,12 +78,12 @@ impl Table {
         for symbol in symbols.iter_mut().take(num_symbols) {
             let sym = br.read(max_bits)? as usize;
             if sym >= al_size {
-                return Err(Error::InvalidHuffman);
+                return Err(at!(Error::InvalidHuffman));
             }
             *symbol = sym as u16;
         }
         if (0..num_symbols - 1).any(|i| symbols[..i].contains(&symbols[i + 1])) {
-            return Err(Error::InvalidHuffman);
+            return Err(at!(Error::InvalidHuffman));
         }
 
         let special_4_symbols = if num_symbols == 4 {
@@ -100,7 +101,7 @@ impl Table {
                 TABLE_SIZE
             ]),
             (2, _) => {
-                let mut ret = Vec::new_with_capacity(TABLE_SIZE)?;
+                let mut ret = Vec::new_with_capacity(TABLE_SIZE).map_err(|e| at!(Error::from(e)))?;
                 symbols[0..2].sort_unstable();
                 for _ in 0..(TABLE_SIZE >> 1) {
                     ret.push(TableEntry {
@@ -115,7 +116,7 @@ impl Table {
                 Ok(ret)
             }
             (3, _) => {
-                let mut ret = Vec::new_with_capacity(TABLE_SIZE)?;
+                let mut ret = Vec::new_with_capacity(TABLE_SIZE).map_err(|e| at!(Error::from(e)))?;
                 symbols[1..3].sort_unstable();
                 for _ in 0..(TABLE_SIZE >> 2) {
                     ret.push(TableEntry {
@@ -138,7 +139,7 @@ impl Table {
                 Ok(ret)
             }
             (4, false) => {
-                let mut ret = Vec::new_with_capacity(TABLE_SIZE)?;
+                let mut ret = Vec::new_with_capacity(TABLE_SIZE).map_err(|e| at!(Error::from(e)))?;
                 symbols.sort_unstable();
                 for _ in 0..(TABLE_SIZE >> 2) {
                     ret.push(TableEntry {
@@ -161,7 +162,7 @@ impl Table {
                 Ok(ret)
             }
             (4, true) => {
-                let mut ret = Vec::new_with_capacity(TABLE_SIZE)?;
+                let mut ret = Vec::new_with_capacity(TABLE_SIZE).map_err(|e| at!(Error::from(e)))?;
                 symbols[2..4].sort_unstable();
                 for _ in 0..(TABLE_SIZE >> 3) {
                     ret.push(TableEntry {
@@ -252,7 +253,7 @@ impl Table {
                 repeat += br.read(extra_bits as usize)? as usize + 3;
                 let repeat_delta = repeat - old_repeat;
                 if symbol + repeat_delta > al_size {
-                    return Err(Error::InvalidHuffman);
+                    return Err(at!(Error::InvalidHuffman));
                 }
                 for i in 0..repeat_delta {
                     code_lengths[symbol + i] = repeat_code_len;
@@ -266,7 +267,7 @@ impl Table {
             }
         }
         if space != 0 {
-            return Err(Error::InvalidHuffman);
+            return Err(at!(Error::InvalidHuffman));
         }
         Ok(code_lengths)
     }
@@ -274,7 +275,7 @@ impl Table {
     #[instrument(level = "trace", ret, err)]
     fn build(root_bits: usize, code_lengths: &[u8]) -> Result<Vec<TableEntry>> {
         if code_lengths.len() > 1 << HUFFMAN_MAX_BITS {
-            return Err(Error::InvalidHuffman);
+            return Err(at!(Error::InvalidHuffman));
         }
         let mut counts = [0u16; HUFFMAN_MAX_BITS + 1];
         for &v in code_lengths.iter() {
@@ -430,7 +431,7 @@ impl Table {
                     }
                 }
                 if num_codes != 1 && space != 0 {
-                    return Err(Error::InvalidHuffman);
+                    return Err(at!(Error::InvalidHuffman));
                 }
                 let code_lengths =
                     Table::decode_huffman_code_lengths(code_length_code_lengths, al_size, br)?;
@@ -491,12 +492,12 @@ impl HuffmanCodes {
             .collect::<Result<_>>()?;
         let max = *alphabet_sizes.iter().max().unwrap();
         if max >= (1 << HUFFMAN_MAX_BITS) {
-            return Err(Error::AlphabetTooLargeHuff(max));
+            return Err(at!(Error::AlphabetTooLargeHuff(max)));
         }
         // Bound total allocations across all tables.
         let total_alphabet: usize = alphabet_sizes.iter().sum();
         if total_alphabet > Self::MAX_TOTAL_ALPHABET_SIZE {
-            return Err(Error::AlphabetTooLargeHuff(total_alphabet));
+            return Err(at!(Error::AlphabetTooLargeHuff(total_alphabet)));
         }
         // Bound per-table allocation relative to remaining input.
         // A Huffman code-length stream needs at least ~1 bit per symbol
@@ -510,7 +511,7 @@ impl HuffmanCodes {
         let input_cap = available.saturating_mul(Self::ALPHABET_BITS_RATIO);
         for &sz in &alphabet_sizes {
             if sz > 1 && sz > input_cap {
-                return Err(Error::AlphabetTooLargeHuff(sz));
+                return Err(at!(Error::AlphabetTooLargeHuff(sz)));
             }
         }
         let tables = alphabet_sizes

--- a/zenjxl-decoder/src/error.rs
+++ b/zenjxl-decoder/src/error.rs
@@ -6,6 +6,7 @@
 use std::collections::TryReserveError;
 
 use thiserror::Error;
+use whereat::At;
 
 use crate::{
     api::{JxlColorType, JxlDataFormat},
@@ -320,4 +321,7 @@ impl From<enough::StopReason> for Error {
     }
 }
 
-pub type Result<T, E = Error> = std::result::Result<T, E>;
+/// Result alias whose default error type carries a `whereat` source-location
+/// trace ([`At<Error>`]). Origins are created with `at!(Error::X)`; propagation
+/// via `?` preserves the trace through `whereat`'s blanket `From<E> for At<E>`.
+pub type Result<T, E = At<Error>> = std::result::Result<T, E>;

--- a/zenjxl-decoder/src/features/patches.rs
+++ b/zenjxl-decoder/src/features/patches.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use num_derive::FromPrimitive;
+use whereat::at;
 use num_traits::FromPrimitive;
 
 use crate::{
@@ -89,10 +90,10 @@ impl PatchBlendMode {
             5 => Ok(PatchBlendMode::BlendBelow),
             6 => Ok(PatchBlendMode::AlphaWeightedAddAbove),
             7 => Ok(PatchBlendMode::AlphaWeightedAddBelow),
-            _ => Err(Error::PatchesInvalidBlendMode(
+            _ => Err(at!(Error::PatchesInvalidBlendMode(
                 i,
                 PatchBlendMode::NUM_BLEND_MODES,
-            )),
+            ))),
         }
     }
 
@@ -248,7 +249,7 @@ impl PatchesDictionary {
         }
 
         // Create a y-interval for each patch.
-        let mut intervals: Vec<PatchInterval> = Vec::new_with_capacity(self.positions.len())?;
+        let mut intervals: Vec<PatchInterval> = Vec::new_with_capacity(self.positions.len()).map_err(|e| at!(Error::from(e)))?;
         for (i, pos) in self.positions.iter().enumerate() {
             let ref_pos = self.ref_positions[pos.ref_pos_idx];
             if ref_pos.xsize > 0 && ref_pos.ysize > 0 {
@@ -313,9 +314,9 @@ impl PatchesDictionary {
             node.start = self.sorted_patches_y0.len();
 
             self.sorted_patches_y1
-                .try_reserve(right_start.saturating_sub(left_end))?;
+                .try_reserve(right_start.saturating_sub(left_end)).map_err(|e| at!(Error::from(e)))?;
             self.sorted_patches_y0
-                .try_reserve(right_start.saturating_sub(left_end))?;
+                .try_reserve(right_start.saturating_sub(left_end)).map_err(|e| at!(Error::from(e)))?;
             for i in (left_end..right_start).rev() {
                 self.sorted_patches_y1
                     .push((intervals[i].y1, intervals[i].idx));
@@ -336,7 +337,7 @@ impl PatchesDictionary {
                 left.start = start;
                 left.num = left_end - left.start;
                 self.patch_tree[next].left_child = self.patch_tree.len() as isize;
-                self.patch_tree.try_reserve(1)?;
+                self.patch_tree.try_reserve(1).map_err(|e| at!(Error::from(e)))?;
                 self.patch_tree.push(left);
             }
             if right_start < end {
@@ -344,7 +345,7 @@ impl PatchesDictionary {
                 right.start = right_start;
                 right.num = end - right.start;
                 self.patch_tree[next].right_child = self.patch_tree.len() as isize;
-                self.patch_tree.try_reserve(1)?;
+                self.patch_tree.try_reserve(1).map_err(|e| at!(Error::from(e)))?;
                 self.patch_tree.push(right);
             }
 
@@ -391,11 +392,11 @@ impl PatchesDictionary {
             .checked_mul(4)
             .ok_or(Error::ArithmeticOverflow)?;
         if num_ref_patch > max_ref_patches {
-            return Err(Error::PatchesTooMany(
+            return Err(at!(Error::PatchesTooMany(
                 "reference patches".to_string(),
                 num_ref_patch,
                 max_ref_patches,
-            ));
+            )));
         }
         let mut total_patches = 0;
         let mut next_size = 1;
@@ -403,7 +404,7 @@ impl PatchesDictionary {
         let mut blendings = Vec::new();
         memory_tracker
             .check_alloc((num_ref_patch * std::mem::size_of::<PatchReferencePosition>()) as u64)?;
-        let mut ref_positions = Vec::new_with_capacity(num_ref_patch)?;
+        let mut ref_positions = Vec::new_with_capacity(num_ref_patch).map_err(|e| at!(Error::from(e)))?;
         for _ in 0..num_ref_patch {
             let reference = patches_reader.read_unsigned(
                 &patches_histograms,
@@ -411,10 +412,10 @@ impl PatchesDictionary {
                 PatchContext::ReferenceFrame as usize,
             ) as usize;
             if reference >= DecoderState::MAX_STORED_FRAMES {
-                return Err(Error::PatchesRefTooLarge(
+                return Err(at!(Error::PatchesRefTooLarge(
                     reference,
                     DecoderState::MAX_STORED_FRAMES,
-                ));
+                )));
             }
 
             let x0 = patches_reader.read_unsigned(
@@ -442,26 +443,26 @@ impl PatchesDictionary {
             let reference_frame = &reference_frames[reference];
             // TODO(firsching): make sure this check is correct in the presence of downsampled extra channels (also in libjxl).
             match reference_frame {
-                None => return Err(Error::PatchesInvalidReference(reference)),
+                None => return Err(at!(Error::PatchesInvalidReference(reference))),
                 Some(reference) => {
                     if !reference.saved_before_color_transform {
-                        return Err(Error::PatchesPostColorTransform());
+                        return Err(at!(Error::PatchesPostColorTransform()));
                     }
                     if x0 + ref_pos_xsize > reference.frame[0].size().0 {
-                        return Err(Error::PatchesInvalidPosition(
+                        return Err(at!(Error::PatchesInvalidPosition(
                             "x".to_string(),
                             x0,
                             ref_pos_xsize,
                             reference.frame[0].size().0,
-                        ));
+                        )));
                     }
                     if y0 + ref_pos_ysize > reference.frame[0].size().1 {
-                        return Err(Error::PatchesInvalidPosition(
+                        return Err(at!(Error::PatchesInvalidPosition(
                             "y".to_string(),
                             y0,
                             ref_pos_ysize,
                             reference.frame[0].size().1,
-                        ));
+                        )));
                     }
                 }
             }
@@ -473,20 +474,20 @@ impl PatchesDictionary {
             ) as usize
                 + 1;
             if id_count > max_patches + 1 {
-                return Err(Error::PatchesTooMany(
+                return Err(at!(Error::PatchesTooMany(
                     "patches".to_string(),
                     id_count,
                     max_patches,
-                ));
+                )));
             }
             total_patches += id_count;
 
             if total_patches > max_patches {
-                return Err(Error::PatchesTooMany(
+                return Err(at!(Error::PatchesTooMany(
                     "patches".to_string(),
                     total_patches,
                     max_patches,
-                ));
+                )));
             }
 
             if next_size < total_patches {
@@ -495,18 +496,18 @@ impl PatchesDictionary {
             }
             // Use saturating_mul to prevent overflow attack bypassing the limit check
             if next_size.saturating_mul(blendings_stride) > max_blending_infos {
-                return Err(Error::PatchesTooMany(
+                return Err(at!(Error::PatchesTooMany(
                     "blending_info".to_string(),
                     total_patches,
                     max_patches,
-                ));
+                )));
             }
-            positions.try_reserve(next_size.saturating_sub(positions.len()))?;
+            positions.try_reserve(next_size.saturating_sub(positions.len())).map_err(|e| at!(Error::from(e)))?;
             // Use checked_mul to fail rather than silently under-allocate
             let blendings_needed = next_size
                 .checked_mul(PatchBlendMode::NUM_BLEND_MODES as usize)
                 .ok_or(Error::ArithmeticOverflow)?;
-            blendings.try_reserve(blendings_needed.saturating_sub(blendings.len()))?;
+            blendings.try_reserve(blendings_needed.saturating_sub(blendings.len())).map_err(|e| at!(Error::from(e)))?;
 
             for i in 0..id_count {
                 let mut pos = PatchPosition {
@@ -534,11 +535,11 @@ impl PatchesDictionary {
                         PatchContext::PatchOffset as usize,
                     );
                     if delta_x < 0 && (-delta_x as usize) > positions.last().unwrap().x {
-                        return Err(Error::PatchesInvalidDelta(
+                        return Err(at!(Error::PatchesInvalidDelta(
                             "x".to_string(),
                             positions.last().unwrap().x,
                             delta_x,
-                        ));
+                        )));
                     }
                     pos.x = (positions.last().unwrap().x as i32 + delta_x) as usize;
 
@@ -548,30 +549,30 @@ impl PatchesDictionary {
                         PatchContext::PatchOffset as usize,
                     );
                     if delta_y < 0 && (-delta_y as usize) > positions.last().unwrap().y {
-                        return Err(Error::PatchesInvalidDelta(
+                        return Err(at!(Error::PatchesInvalidDelta(
                             "y".to_string(),
                             positions.last().unwrap().y,
                             delta_y,
-                        ));
+                        )));
                     }
                     pos.y = (positions.last().unwrap().y as i32 + delta_y) as usize;
                 }
 
                 if pos.x + ref_pos_xsize > xsize {
-                    return Err(Error::PatchesOutOfBounds(
+                    return Err(at!(Error::PatchesOutOfBounds(
                         "x".to_string(),
                         pos.x,
                         ref_pos_xsize,
                         xsize,
-                    ));
+                    )));
                 }
                 if pos.y + ref_pos_ysize > ysize {
-                    return Err(Error::PatchesOutOfBounds(
+                    return Err(at!(Error::PatchesOutOfBounds(
                         "y".to_string(),
                         pos.y,
                         ref_pos_ysize,
                         ysize,
-                    ));
+                    )));
                 }
 
                 for _ in 0..blendings_stride {
@@ -584,10 +585,10 @@ impl PatchesDictionary {
                     ) as u8;
                     let blend_mode = match PatchBlendMode::from_u8(maybe_blend_mode) {
                         None => {
-                            return Err(Error::PatchesInvalidBlendMode(
+                            return Err(at!(Error::PatchesInvalidBlendMode(
                                 maybe_blend_mode,
                                 PatchBlendMode::NUM_BLEND_MODES,
-                            ));
+                            )));
                         }
                         Some(blend_mode) => blend_mode,
                     };
@@ -599,10 +600,10 @@ impl PatchesDictionary {
                             PatchContext::PatchAlphaChannel as usize,
                         ) as usize;
                         if alpha_channel >= num_extra_channels {
-                            return Err(Error::PatchesInvalidAlphaChannel(
+                            return Err(at!(Error::PatchesInvalidAlphaChannel(
                                 alpha_channel,
                                 num_extra_channels,
-                            ));
+                            )));
                         }
                     }
 

--- a/zenjxl-decoder/src/features/spline.rs
+++ b/zenjxl-decoder/src/features/spline.rs
@@ -8,6 +8,7 @@ use std::{
     iter::{self, zip},
     ops,
 };
+use whereat::at;
 
 use crate::{
     bit_reader::BitReader,
@@ -118,12 +119,12 @@ impl Spline {
         )
         .find(|((_, p0), p1)| **p0 == **p1)
         {
-            return Err(Error::SplineAdjacentCoincidingControlPoints(
+            return Err(at!(Error::SplineAdjacentCoincidingControlPoints(
                 index,
                 *p0,
                 index + 1,
                 *p1,
-            ));
+            )));
         }
         Ok(())
     }
@@ -150,24 +151,24 @@ fn validate_spline_point_pos<T: num_traits::ToPrimitive>(x: T, y: T) -> Result<(
     let yi = y.to_i32().unwrap();
     let ok_range = -(1i32 << 23)..(1i32 << 23);
     if !ok_range.contains(&xi) {
-        return Err(Error::SplinesPointOutOfRange(
+        return Err(at!(Error::SplinesPointOutOfRange(
             Point {
                 x: xi as f32,
                 y: yi as f32,
             },
             xi,
             ok_range,
-        ));
+        )));
     }
     if !ok_range.contains(&yi) {
-        return Err(Error::SplinesPointOutOfRange(
+        return Err(at!(Error::SplinesPointOutOfRange(
             Point {
                 x: xi as f32,
                 y: yi as f32,
             },
             yi,
             ok_range,
-        ));
+        )));
     }
     Ok(())
 }
@@ -195,12 +196,12 @@ impl QuantizedSpline {
             splines_reader.read_unsigned(splines_histograms, br, NUM_CONTROL_POINTS_CONTEXT);
         *total_num_control_points += num_control_points;
         if *total_num_control_points > max_control_points {
-            return Err(Error::SplinesTooManyControlPoints(
+            return Err(at!(Error::SplinesTooManyControlPoints(
                 *total_num_control_points,
                 max_control_points,
-            ));
+            )));
         }
-        let mut control_points = Vec::new_with_capacity(num_control_points as usize)?;
+        let mut control_points = Vec::new_with_capacity(num_control_points as usize).map_err(|e| at!(Error::from(e)))?;
         for _ in 0..num_control_points {
             let x =
                 splines_reader.read_signed(splines_histograms, br, CONTROL_POINTS_CONTEXT) as i64;
@@ -210,7 +211,7 @@ impl QuantizedSpline {
             // Add check that double deltas are not outrageous (not in spec).
             let max_delta_delta = x.abs().max(y.abs());
             if max_delta_delta >= DELTA_LIMIT {
-                return Err(Error::SplinesDeltaLimit(max_delta_delta, DELTA_LIMIT));
+                return Err(at!(Error::SplinesDeltaLimit(max_delta_delta, DELTA_LIMIT)));
             }
         }
         // Decode DCTs and populate the QuantizedSpline struct
@@ -247,7 +248,7 @@ impl QuantizedSpline {
         let area_limit = area_limit(image_size);
 
         let mut result = Spline {
-            control_points: Vec::new_with_capacity(self.control_points.len() + 1)?,
+            control_points: Vec::new_with_capacity(self.control_points.len() + 1).map_err(|e| at!(Error::from(e)))?,
             ..Default::default()
         };
 
@@ -274,10 +275,10 @@ impl QuantizedSpline {
                 current_delta_x.unsigned_abs() as u64 + current_delta_y.unsigned_abs() as u64;
 
             if manhattan_distance > area_limit {
-                return Err(Error::SplinesDistanceTooLarge(
+                return Err(at!(Error::SplinesDistanceTooLarge(
                     manhattan_distance,
                     area_limit,
-                ));
+                )));
             }
 
             current_x += current_delta_x;
@@ -756,10 +757,10 @@ impl Splines {
             )?;
             total_estimated_area_reached += spline.estimated_area_reached;
             if total_estimated_area_reached > area_limit {
-                return Err(Error::SplinesAreaTooLarge(
+                return Err(at!(Error::SplinesAreaTooLarge(
                     total_estimated_area_reached,
                     area_limit,
-                ));
+                )));
             }
             spline.validate_adjacent_point_coincidence()?;
             splines.push(spline);
@@ -804,11 +805,11 @@ impl Splines {
         segments_by_y.sort_by_key(|segment| segment.0);
 
         self.segment_indices.clear();
-        self.segment_indices.try_reserve(segments_by_y.len())?;
+        self.segment_indices.try_reserve(segments_by_y.len()).map_err(|e| at!(Error::from(e)))?;
         self.segment_indices.resize(segments_by_y.len(), 0);
 
         self.segment_y_start.clear();
-        self.segment_y_start.try_reserve(image_ysize as usize + 1)?;
+        self.segment_y_start.try_reserve(image_ysize as usize + 1).map_err(|e| at!(Error::from(e)))?;
         self.segment_y_start.resize(image_ysize as usize + 1, 0);
 
         for (i, segment) in segments_by_y.iter().enumerate() {
@@ -842,7 +843,7 @@ impl Splines {
         let max_control_points =
             hard_limit.min(num_pixels / MAX_NUM_CONTROL_POINTS_PER_PIXEL_RATIO);
         if num_splines > max_control_points {
-            return Err(Error::SplinesTooMany(num_splines, max_control_points));
+            return Err(at!(Error::SplinesTooMany(num_splines, max_control_points)));
         }
 
         let mut starting_points = Vec::new();
@@ -865,10 +866,10 @@ impl Splines {
             // It is not in spec, but reasonable limit to avoid overflows.
             let max_coordinate = x.abs().max(y.abs());
             if max_coordinate >= SPLINE_POS_LIMIT {
-                return Err(Error::SplinesCoordinatesLimit(
+                return Err(at!(Error::SplinesCoordinatesLimit(
                     max_coordinate,
                     SPLINE_POS_LIMIT,
-                ));
+                )));
             }
 
             starting_points.push(Point {
@@ -914,7 +915,7 @@ mod test_splines {
     use test_log::test;
 
     use crate::{
-        error::{Error, Result},
+        error::Result,
         features::spline::SplineSegment,
         frame::color_correlation_map::ColorCorrelationParams,
         util::test::{assert_all_almost_abs_eq, assert_almost_abs_eq, assert_almost_eq},
@@ -938,7 +939,7 @@ mod test_splines {
     }
 
     #[test]
-    fn dequantize() -> Result<(), Error> {
+    fn dequantize() -> Result<()> {
         // Golden data generated by libjxl.
         let quantized_and_dequantized = [
             (
@@ -1556,7 +1557,7 @@ mod test_splines {
     }
 
     #[test]
-    fn centripetal_catmull_rom_spline() -> Result<(), Error> {
+    fn centripetal_catmull_rom_spline() -> Result<()> {
         let control_points = vec![Point { x: 1.0, y: 2.0 }, Point { x: 4.0, y: 3.0 }];
         let want_result = [
             Point { x: 1.0, y: 2.0 },
@@ -1623,7 +1624,7 @@ mod test_splines {
     }
 
     #[test]
-    fn equally_spaced_points() -> Result<(), Error> {
+    fn equally_spaced_points() -> Result<()> {
         let desired_rendering_distance = 10.0f32;
         let segments = [
             Point { x: 0.0, y: 0.0 },
@@ -1662,7 +1663,7 @@ mod test_splines {
     }
 
     #[test]
-    fn dct32() -> Result<(), Error> {
+    fn dct32() -> Result<()> {
         let mut dct = Dct32::default();
         for (i, coeff) in dct.0.iter_mut().enumerate() {
             *coeff = 0.05f32 * i as f32;
@@ -1743,7 +1744,7 @@ mod test_splines {
     }
 
     #[test]
-    fn spline_segments_add_segment() -> Result<(), Error> {
+    fn spline_segments_add_segment() -> Result<()> {
         let mut splines = Splines::default();
         let mut segments_by_y = Vec::<(u64, usize)>::new();
 
@@ -1785,7 +1786,7 @@ mod test_splines {
     }
 
     #[test]
-    fn spline_segments_add_segments_from_points() -> Result<(), Error> {
+    fn spline_segments_add_segments_from_points() -> Result<()> {
         let mut splines = Splines::default();
         let mut segments_by_y = Vec::<(u64, usize)>::new();
         let mut color_dct = [Dct32::default(); 3];
@@ -1861,7 +1862,7 @@ mod test_splines {
     }
 
     #[test]
-    fn init_draw_cache() -> Result<(), Error> {
+    fn init_draw_cache() -> Result<()> {
         let mut splines = Splines {
             splines: vec![
                 QuantizedSpline {

--- a/zenjxl-decoder/src/frame/block_context_map.rs
+++ b/zenjxl-decoder/src/frame/block_context_map.rs
@@ -10,6 +10,7 @@ use crate::{
     frame::coeff_order::NUM_ORDERS,
     util::ShiftRightCeil,
 };
+use whereat::at;
 
 pub const NON_ZERO_BUCKETS: usize = 37;
 
@@ -59,7 +60,7 @@ impl BlockContextMap {
     pub fn num_ac_contexts(&self) -> usize {
         self.num_contexts * (NON_ZERO_BUCKETS + ZERO_DENSITY_CONTEXT_COUNT)
     }
-    pub fn read(br: &mut BitReader) -> Result<BlockContextMap, Error> {
+    pub fn read(br: &mut BitReader) -> Result<BlockContextMap> {
         if br.read(1)? == 1 {
             Ok(BlockContextMap {
                 lf_thresholds: [vec![], vec![], vec![]],
@@ -102,17 +103,17 @@ impl BlockContextMap {
                     + 1;
             }
             if num_lf_contexts * (num_qf_thresholds + 1) > 64 {
-                return Err(Error::BlockContextMapSizeTooBig(
+                return Err(at!(Error::BlockContextMapSizeTooBig(
                     num_lf_contexts,
                     num_qf_thresholds,
-                ));
+                )));
             }
             let context_map_size = 3 * NUM_ORDERS * num_lf_contexts * (num_qf_thresholds + 1);
             let context_map = decode_context_map(context_map_size, br)?;
             assert_eq!(context_map.len(), context_map_size);
             let num_contexts = *context_map.iter().max().unwrap() as usize + 1;
             if num_contexts > 16 {
-                Err(Error::TooManyBlockContexts)
+                Err(at!(Error::TooManyBlockContexts))
             } else {
                 Ok(BlockContextMap {
                     lf_thresholds,

--- a/zenjxl-decoder/src/frame/decode.rs
+++ b/zenjxl-decoder/src/frame/decode.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use std::collections::BTreeSet;
+use whereat::at;
 use std::sync::Arc;
 
 use super::render::pipeline;
@@ -179,7 +180,7 @@ impl Frame {
                 if let Some([a, b, c]) = &decoder_state.lf_frames[frame_header.lf_level as usize] {
                     Some([a.try_clone()?, b.try_clone()?, c.try_clone()?])
                 } else {
-                    return Err(Error::NoLfFrame(frame_header.lf_level));
+                    return Err(at!(Error::NoLfFrame(frame_header.lf_level)));
                 }
             } else {
                 Some([
@@ -294,7 +295,7 @@ impl Frame {
             .entries
             .iter()
             .scan(br, |br, count| Some(br.split_at(*count as usize)))
-            .collect::<Result<Vec<_>>>()?;
+            .collect::<Result<Vec<_>, Error>>()?;
         if !self.toc.permuted {
             return Ok(ret);
         }
@@ -833,10 +834,10 @@ impl Frame {
             tracker.try_allocate(alloc_bytes)?;
             let mut channels: [Vec<Vec<i32>>; 3] = [Vec::new(), Vec::new(), Vec::new()];
             for ch in &mut channels {
-                ch.try_reserve_exact(num_groups)?;
+                ch.try_reserve_exact(num_groups).map_err(|e| at!(Error::from(e)))?;
                 for _ in 0..num_groups {
                     let mut v: Vec<i32> = Vec::new();
-                    v.try_reserve_exact(coeffs_per_group)?;
+                    v.try_reserve_exact(coeffs_per_group).map_err(|e| at!(Error::from(e)))?;
                     v.resize(coeffs_per_group, 0);
                     ch.push(v);
                 }

--- a/zenjxl-decoder/src/frame/group.rs
+++ b/zenjxl-decoder/src/frame/group.rs
@@ -7,6 +7,7 @@
 #![allow(clippy::too_many_arguments)]
 
 use num_traits::Float;
+use whereat::at;
 
 use crate::transforms::{transform::*, transform_map::*};
 
@@ -388,10 +389,10 @@ impl<'a, 'b> PassInfo<'a, 'b> {
         // two. Reject those here, otherwise downstream indexing into the
         // per-pass histogram context map can go out of bounds.
         if histogram_index >= hf_global.num_histograms as usize {
-            return Err(Error::InvalidHistogramIndex(
+            return Err(at!(Error::InvalidHistogramIndex(
                 histogram_index,
                 hf_global.num_histograms as usize,
-            ));
+            )));
         }
         let reader = Some(SymbolReader::new(
             &hf_global.passes[pass].histograms,
@@ -455,7 +456,7 @@ pub fn decode_vardct_group(
     buffers: &mut VarDctBuffers,
     tracker: &MemoryTracker,
     #[cfg(feature = "jpeg")] mut jpeg_coeffs: Option<&mut [Vec<i16>; 3]>,
-) -> Result<(), Error> {
+) -> Result<()> {
     crate::profile!(entropy_decode);
     let x_dm_multiplier = (1.0 / (1.25)).powf(frame_header.x_qm_scale as f32 - 2.0);
     let b_dm_multiplier = (1.0 / (1.25)).powf(frame_header.b_qm_scale as f32 - 2.0);
@@ -648,7 +649,7 @@ pub fn decode_vardct_group(
                         sbx[c], sby[c]
                     );
                     if nonzeros + num_blocks > num_coeffs {
-                        return Err(Error::InvalidNumNonZeros(nonzeros, num_blocks));
+                        return Err(at!(Error::InvalidNumNonZeros(nonzeros, num_blocks)));
                     }
                     for iy in 0..cy {
                         let nzrow = num_nzeros[c].row_mut(sby[c] + iy);
@@ -675,7 +676,7 @@ pub fn decode_vardct_group(
                         current_coeffs[coeff_index] += coeff;
                     }
                     if nonzeros != 0 {
-                        return Err(Error::EndOfBlockResidualNonZeros(nonzeros));
+                        return Err(at!(Error::EndOfBlockResidualNonZeros(nonzeros)));
                     }
                 }
             }

--- a/zenjxl-decoder/src/frame/mod.rs
+++ b/zenjxl-decoder/src/frame/mod.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use std::{collections::BTreeSet, sync::Arc};
+use whereat::at;
 
 #[cfg(feature = "jpeg")]
 use crate::util::TryVecExt;
@@ -180,7 +181,7 @@ impl DecoderState {
 
     /// Check cancellation status and return error if cancelled.
     pub fn check_cancelled(&self) -> crate::error::Result<()> {
-        Ok(self.stop.check()?)
+        self.stop.check().map_err(|e| at!(crate::error::Error::from(e)))
     }
 
     pub fn extra_channel_info(&self) -> &Vec<ExtraChannelInfo> {
@@ -335,11 +336,11 @@ impl Frame {
             if let Some(limit) = self.decoder_state.limits.max_reference_frames
                 && slot >= limit
             {
-                return Err(crate::error::Error::LimitExceeded {
+                return Err(at!(crate::error::Error::LimitExceeded {
                     resource: "reference_frames",
                     actual: (slot + 1) as u64,
                     limit: limit as u64,
-                });
+                }));
             }
             info!("Saving frame in slot {}", self.header.save_as_reference);
             let rf = Arc::get_mut(&mut self.decoder_state.reference_frames)
@@ -622,7 +623,7 @@ mod test {
     use std::panic;
 
     use crate::{
-        error::{Error, Result},
+        error::Result,
         features::spline::Point,
         util::test::assert_almost_abs_eq,
     };
@@ -639,7 +640,7 @@ mod test {
     }
 
     #[test]
-    fn splines() -> Result<(), Error> {
+    fn splines() -> Result<()> {
         let verify_frame = move |frame: &Frame, _| {
             let lf_global = frame.lf_global.as_ref().unwrap();
             let splines = lf_global.splines.as_ref().unwrap();
@@ -699,7 +700,7 @@ mod test {
     }
 
     #[test]
-    fn noise() -> Result<(), Error> {
+    fn noise() -> Result<()> {
         let verify_frame = |frame: &Frame, _| {
             let lf_global = frame.lf_global.as_ref().unwrap();
             let noise = lf_global.noise.as_ref().unwrap();
@@ -722,7 +723,7 @@ mod test {
     }
 
     #[test]
-    fn patches() -> Result<(), Error> {
+    fn patches() -> Result<()> {
         let verify_frame = |frame: &Frame, frame_index| {
             if frame_index == 0 {
                 assert!(!frame.header().has_patches());
@@ -744,7 +745,7 @@ mod test {
     }
 
     #[test]
-    fn multiple_lf_420() -> Result<(), Error> {
+    fn multiple_lf_420() -> Result<()> {
         let verify_frame = |frame: &Frame, _| {
             assert!(frame.header().is420());
             let Some(lf_image) = &frame.lf_image else {
@@ -774,7 +775,7 @@ mod test {
     }
 
     #[test]
-    fn xyb_grayscale_patches() -> Result<(), Error> {
+    fn xyb_grayscale_patches() -> Result<()> {
         let verify_frame = |frame: &Frame, frame_index| {
             if frame_index == 0 {
                 assert_eq!(

--- a/zenjxl-decoder/src/frame/modular/decode/bitstream.rs
+++ b/zenjxl-decoder/src/frame/modular/decode/bitstream.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use super::channel::decode_modular_channel;
+use whereat::at;
 use crate::{
     bit_reader::BitReader,
     entropy_coding::decode::SymbolReader,
@@ -53,7 +54,7 @@ pub fn decode_modular_subbitstream(
     };
 
     if header.use_global_tree && global_tree.is_none() {
-        return Err(Error::NoGlobalTree);
+        return Err(at!(Error::NoGlobalTree));
     }
     let local_tree = if !header.use_global_tree {
         let num_local_samples = buffers

--- a/zenjxl-decoder/src/frame/modular/decode/specialized_trees.rs
+++ b/zenjxl-decoder/src/frame/modular/decode/specialized_trees.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use std::{collections::VecDeque, ops::Range};
+use whereat::at;
 
 use crate::{
     bit_reader::BitReader,
@@ -415,8 +416,8 @@ pub fn specialize_tree(
     // TODO(veluca): consider skipping the pruning if header.uses_global_tree is true.
     let mut pruned_tree = Vec::new();
     let mut queue = VecDeque::new();
-    pruned_tree.try_reserve(tree.nodes.len())?;
-    queue.try_reserve(tree.nodes.len())?;
+    pruned_tree.try_reserve(tree.nodes.len()).map_err(|e| at!(crate::error::Error::from(e)))?;
+    queue.try_reserve(tree.nodes.len()).map_err(|e| at!(crate::error::Error::from(e)))?;
     queue.push_front(0);
 
     let mut uses_wp = false;

--- a/zenjxl-decoder/src/frame/modular/mod.rs
+++ b/zenjxl-decoder/src/frame/modular/mod.rs
@@ -13,6 +13,7 @@ use std::{
         atomic::{AtomicUsize, Ordering},
     },
 };
+use whereat::at;
 
 use crate::transforms::transform_map::*;
 use crate::{
@@ -1260,14 +1261,14 @@ pub(crate) fn decode_hf_metadata_into_rects(
         for x in 0..r.size.0 {
             let epf_val = epf_row_in[x];
             if !(0..8).contains(&epf_val) {
-                return Err(Error::InvalidEpfValue(epf_val));
+                return Err(at!(Error::InvalidEpfValue(epf_val)));
             }
             epf_row_out[x] = epf_val as u8;
             if transform_map_rect.row(y)[x] != HfTransformType::INVALID_TRANSFORM {
                 continue;
             }
             if num >= count {
-                return Err(Error::InvalidVarDCTTransformMap);
+                return Err(at!(Error::InvalidVarDCTTransformMap));
             }
             let raw_transform = transform_image.row(0)[num];
             let raw_quant = 1 + transform_image.row(1)[num].clamp(0, 255);
@@ -1277,11 +1278,11 @@ pub(crate) fn decode_hf_metadata_into_rects(
             let cx = covered_blocks_x(transform_type) as usize;
             let cy = covered_blocks_y(transform_type) as usize;
             if (cx > 1 || cy > 1) && !frame_header.is444() {
-                return Err(Error::InvalidBlockSizeForChromaSubsampling);
+                return Err(at!(Error::InvalidBlockSizeForChromaSubsampling));
             }
             let next_group = ((x / 32 + 1) * 32, (y / 32 + 1) * 32);
             if x + cx > min(r.size.0, next_group.0) || y + cy > min(r.size.1, next_group.1) {
-                return Err(Error::HFBlockOutOfBounds);
+                return Err(at!(Error::HFBlockOutOfBounds));
             }
             let transform_id = raw_transform as u8;
             for iy in 0..cy {

--- a/zenjxl-decoder/src/frame/modular/predict.rs
+++ b/zenjxl-decoder/src/frame/modular/predict.rs
@@ -9,6 +9,7 @@ use crate::{
     image::Image,
     util::{TryVecExt, floor_log2_nonzero},
 };
+use whereat::at;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 
@@ -46,7 +47,7 @@ impl Predictor {
 impl TryFrom<u32> for Predictor {
     type Error = Error;
 
-    fn try_from(value: u32) -> Result<Self> {
+    fn try_from(value: u32) -> Result<Self, Error> {
         Self::from_u32(value).ok_or(Error::InvalidPredictor(value))
     }
 }
@@ -425,8 +426,8 @@ impl WeightedPredictorState {
             // Position-major layout: errors for same position are contiguous
             // Layout: [pos0: p0,p1,p2,p3] [pos1: p0,p1,p2,p3] ...
             // This gives better cache locality when accessing all predictors for a position
-            pred_errors_buffer: Vec::try_from_elem(0u32, num_errors * NUM_PREDICTORS)?,
-            error: Vec::try_from_elem(0i32, num_errors)?,
+            pred_errors_buffer: Vec::try_from_elem(0u32, num_errors * NUM_PREDICTORS).map_err(|e| at!(Error::from(e)))?,
+            error: Vec::try_from_elem(0i32, num_errors).map_err(|e| at!(Error::from(e)))?,
             wp_header: wp_header.clone(),
         })
     }

--- a/zenjxl-decoder/src/frame/modular/transforms/apply.rs
+++ b/zenjxl-decoder/src/frame/modular/transforms/apply.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use std::fmt::Debug;
+use whereat::at;
 
 use num_traits::FromPrimitive;
 
@@ -423,18 +424,18 @@ fn check_equal_channels(
     num: usize,
 ) -> Result<()> {
     if first_chan + num > channels.len() {
-        return Err(Error::InvalidChannelRange(
+        return Err(at!(Error::InvalidChannelRange(
             first_chan,
             first_chan + num,
             channels.len(),
-        ));
+        )));
     }
     for inc in 1..num {
         if !channels[first_chan]
             .1
             .is_equivalent(&channels[first_chan + inc].1)
         {
-            return Err(Error::MixingDifferentChannels);
+            return Err(at!(Error::MixingDifferentChannels));
         }
     }
     Ok(())
@@ -503,7 +504,7 @@ fn meta_apply_single_transform(
                     let chan = &channels[begin_channel + ic].1;
                     let new_shift = if let Some(shift) = chan.shift {
                         if shift.0 > 30 || shift.1 > 30 {
-                            return Err(Error::TooManySqueezes);
+                            return Err(at!(Error::TooManySqueezes));
                         }
                         if horizontal {
                             Some((shift.0 + 1, shift.1))

--- a/zenjxl-decoder/src/frame/modular/transforms/squeeze.rs
+++ b/zenjxl-decoder/src/frame/modular/transforms/squeeze.rs
@@ -6,6 +6,7 @@
 use jxl_simd::{
     F32SimdVec, I32SimdVec, SimdDescriptor, SimdMask, U32SimdVec, shl, shr, simd_function,
 };
+use whereat::at;
 
 use crate::{
     error::{Error, Result},
@@ -24,18 +25,18 @@ pub fn check_squeeze_params(
 ) -> Result<()> {
     let end_channel = (params.begin_channel + params.num_channels) as usize;
     if end_channel > channels.len() {
-        return Err(Error::InvalidChannelRange(
+        return Err(at!(Error::InvalidChannelRange(
             params.begin_channel as usize,
             params.num_channels as usize,
             channels.len(),
-        ));
+        )));
     }
     if channels[params.begin_channel as usize].1.is_meta() != channels[end_channel - 1].1.is_meta()
     {
-        return Err(Error::MixingDifferentChannels);
+        return Err(at!(Error::MixingDifferentChannels));
     }
     if channels[params.begin_channel as usize].1.is_meta() && !params.in_place {
-        return Err(Error::MetaSqueezeRequiresInPlace);
+        return Err(at!(Error::MetaSqueezeRequiresInPlace));
     }
     Ok(())
 }

--- a/zenjxl-decoder/src/frame/modular/tree.rs
+++ b/zenjxl-decoder/src/frame/modular/tree.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use std::fmt::Debug;
+use whereat::at;
 
 use super::{Predictor, predict::WeightedPredictorState};
 use crate::{
@@ -106,7 +107,7 @@ fn validate_tree(tree: &[TreeNode], num_properties: usize) -> Result<()> {
 
     while let Some(mut frame) = stack.pop() {
         if frame.depth > HEIGHT_LIMIT {
-            return Err(Error::TreeTooTall(frame.depth, HEIGHT_LIMIT));
+            return Err(at!(Error::TreeTooTall(frame.depth, HEIGHT_LIMIT)));
         }
 
         match (frame.stage, tree[frame.node]) {
@@ -127,7 +128,7 @@ fn validate_tree(tree: &[TreeNode], num_properties: usize) -> Result<()> {
                 let p = property as usize;
                 let (l, u) = property_ranges[p];
                 if l > val || u <= val {
-                    return Err(Error::TreeSplitOnEmptyRange(property, val, l, u));
+                    return Err(at!(Error::TreeSplitOnEmptyRange(property, val, l, u)));
                 }
 
                 frame.stage = Stage::AfterLeft;
@@ -156,7 +157,7 @@ fn validate_tree(tree: &[TreeNode], num_properties: usize) -> Result<()> {
                 let p = property as usize;
                 let (l, u) = property_ranges[p];
                 if l > val || u <= val {
-                    return Err(Error::TreeSplitOnEmptyRange(property, val, l, u));
+                    return Err(at!(Error::TreeSplitOnEmptyRange(property, val, l, u)));
                 }
 
                 frame.stage = Stage::AfterRight;
@@ -446,10 +447,10 @@ impl Tree {
         let mut max_property = 0;
         while to_decode > 0 {
             if tree.len() > size_limit {
-                return Err(Error::TreeTooLarge(tree.len(), size_limit));
+                return Err(at!(Error::TreeTooLarge(tree.len(), size_limit)));
             }
             if tree.len() >= tree.capacity() {
-                tree.try_reserve(tree.len() * 2 + 1)?;
+                tree.try_reserve(tree.len() * 2 + 1).map_err(|e| at!(Error::from(e)))?;
             }
             to_decode -= 1;
             let property = tree_reader.read_unsigned(&tree_histograms, br, PROPERTY_CONTEXT);
@@ -457,7 +458,7 @@ impl Tree {
             if let Some(property) = property.checked_sub(1) {
                 // inner node.
                 if property > 255 {
-                    return Err(Error::InvalidProperty(property));
+                    return Err(at!(Error::InvalidProperty(property)));
                 }
                 max_property = max_property.max(property);
                 let splitval = tree_reader.read_signed(&tree_histograms, br, SPLIT_VAL_CONTEXT);
@@ -481,13 +482,13 @@ impl Tree {
                 let mul_log =
                     tree_reader.read_unsigned(&tree_histograms, br, MULTIPLIER_LOG_CONTEXT);
                 if mul_log >= 31 {
-                    return Err(Error::TreeMultiplierTooLarge(mul_log, 31));
+                    return Err(at!(Error::TreeMultiplierTooLarge(mul_log, 31)));
                 }
                 let mul_bits =
                     tree_reader.read_unsigned(&tree_histograms, br, MULTIPLIER_BITS_CONTEXT);
                 let multiplier = (mul_bits as u64 + 1) << mul_log;
                 if multiplier > (u32::MAX as u64) {
-                    return Err(Error::TreeMultiplierBitsTooLarge(mul_bits, mul_log));
+                    return Err(at!(Error::TreeMultiplierBitsTooLarge(mul_bits, mul_log)));
                 }
                 let node = TreeNode::Leaf {
                     predictor,
@@ -545,7 +546,7 @@ impl Tree {
             return Ok(vec![]);
         }
 
-        let mut flat_nodes = Vec::new_with_capacity(nodes.len())?;
+        let mut flat_nodes = Vec::new_with_capacity(nodes.len()).map_err(|e| at!(Error::from(e)))?;
         let mut queue: VecDeque<usize> = VecDeque::new();
         queue.push_back(0); // Start with root
 
@@ -615,7 +616,7 @@ impl Tree {
                 // Split node: child_id + 3 must be a valid index
                 let max_child = node.child_id as usize + 3;
                 if max_child >= len {
-                    return Err(Error::TreeTooLarge(max_child + 1, len));
+                    return Err(at!(Error::TreeTooLarge(max_child + 1, len)));
                 }
             }
         }

--- a/zenjxl-decoder/src/frame/quant_weights.rs
+++ b/zenjxl-decoder/src/frame/quant_weights.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use std::{borrow::Cow, f32::consts::SQRT_2, sync::OnceLock};
+use whereat::at;
 
 use crate::util::f16;
 
@@ -69,7 +70,7 @@ impl DctQuantWeightParams {
                 *item = f32::from(f16::from_bits(br.read(16)? as u16));
             }
             if row[0] < ALMOST_ZERO {
-                return Err(HfQuantFactorTooSmall(row[0]));
+                return Err(at!(HfQuantFactorTooSmall(row[0])));
             }
             row[0] *= 64.0;
         }
@@ -137,17 +138,17 @@ impl QuantEncoding {
             0 => Ok(Self::Library),
             1 => {
                 if required_size != 1 {
-                    return Err(InvalidQuantEncoding {
+                    return Err(at!(InvalidQuantEncoding {
                         mode,
                         required_size,
-                    });
+                    }));
                 }
                 let mut xyb_weights = [[0.0; 3]; 3];
                 for row in xyb_weights.iter_mut() {
                     for item in row.iter_mut() {
                         *item = f32::from(f16::from_bits(br.read(16)? as u16));
                         if item.abs() < ALMOST_ZERO {
-                            return Err(HfQuantFactorTooSmall(*item));
+                            return Err(at!(HfQuantFactorTooSmall(*item)));
                         }
                         *item *= 64.0;
                     }
@@ -156,17 +157,17 @@ impl QuantEncoding {
             }
             2 => {
                 if required_size != 1 {
-                    return Err(InvalidQuantEncoding {
+                    return Err(at!(InvalidQuantEncoding {
                         mode,
                         required_size,
-                    });
+                    }));
                 }
                 let mut xyb_weights = [[0.0; 6]; 3];
                 for row in xyb_weights.iter_mut() {
                     for item in row.iter_mut() {
                         *item = f32::from(f16::from_bits(br.read(16)? as u16));
                         if item.abs() < ALMOST_ZERO {
-                            return Err(HfQuantFactorTooSmall(*item));
+                            return Err(at!(HfQuantFactorTooSmall(*item)));
                         }
                         *item *= 64.0;
                     }
@@ -175,17 +176,17 @@ impl QuantEncoding {
             }
             3 => {
                 if required_size != 1 {
-                    return Err(InvalidQuantEncoding {
+                    return Err(at!(InvalidQuantEncoding {
                         mode,
                         required_size,
-                    });
+                    }));
                 }
                 let mut xyb_mul = [[0.0; 2]; 3];
                 for row in xyb_mul.iter_mut() {
                     for item in row.iter_mut() {
                         *item = f32::from(f16::from_bits(br.read(16)? as u16));
                         if item.abs() < ALMOST_ZERO {
-                            return Err(HfQuantFactorTooSmall(*item));
+                            return Err(at!(HfQuantFactorTooSmall(*item)));
                         }
                     }
                 }
@@ -194,16 +195,16 @@ impl QuantEncoding {
             }
             4 => {
                 if required_size != 1 {
-                    return Err(InvalidQuantEncoding {
+                    return Err(at!(InvalidQuantEncoding {
                         mode,
                         required_size,
-                    });
+                    }));
                 }
                 let mut xyb_mul = [0.0; 3];
                 for item in xyb_mul.iter_mut() {
                     *item = f32::from(f16::from_bits(br.read(16)? as u16));
                     if item.abs() < ALMOST_ZERO {
-                        return Err(HfQuantFactorTooSmall(*item));
+                        return Err(at!(HfQuantFactorTooSmall(*item)));
                     }
                 }
                 let params = DctQuantWeightParams::decode(br)?;
@@ -211,10 +212,10 @@ impl QuantEncoding {
             }
             5 => {
                 if required_size != 1 {
-                    return Err(InvalidQuantEncoding {
+                    return Err(at!(InvalidQuantEncoding {
                         mode,
                         required_size,
-                    });
+                    }));
                 }
                 let mut weights = [[0.0; 9]; 3];
                 for row in weights.iter_mut() {
@@ -241,7 +242,7 @@ impl QuantEncoding {
                 let qtable_den = f32::from(f16::from_bits(br.read(16)? as u16));
                 if qtable_den < ALMOST_ZERO {
                     // qtable[] values are already checked for <= 0 so the denominator may not be negative.
-                    return Err(InvalidRawQuantTable);
+                    return Err(at!(InvalidRawQuantTable));
                 }
                 let bit_depth = BitDepth::integer_samples(8);
                 let mut image = [
@@ -270,16 +271,16 @@ impl QuantEncoding {
                     {
                         qtable.push(entry);
                         if entry <= 0 {
-                            return Err(InvalidRawQuantTable);
+                            return Err(at!(InvalidRawQuantTable));
                         }
                     }
                 }
                 Ok(Self::Raw { qtable, qtable_den })
             }
-            _ => Err(InvalidQuantEncoding {
+            _ => Err(at!(InvalidQuantEncoding {
                 mode,
                 required_size,
-            }),
+            })),
         }
     }
 }
@@ -932,7 +933,7 @@ impl DequantMatrices {
         match encoding {
             QuantEncoding::Library => {
                 // Library encoding should be resolved by the caller.
-                return Err(InvalidQuantEncodingMode);
+                return Err(at!(InvalidQuantEncodingMode));
             }
             QuantEncoding::Identity { xyb_weights } => {
                 for c in 0..3 {
@@ -1008,7 +1009,7 @@ impl DequantMatrices {
             }
             QuantEncoding::Raw { qtable, qtable_den } => {
                 if qtable.len() != 3 * num {
-                    return Err(InvalidRawQuantTable);
+                    return Err(at!(InvalidRawQuantTable));
                 }
                 for i in 0..3 * num {
                     weights[i] = 1f32 / (qtable_den * qtable[i] as f32);
@@ -1047,12 +1048,12 @@ impl DequantMatrices {
                     let mut bands = [0f32; 4];
                     bands[0] = afv_weights[c][5];
                     if bands[0] < ALMOST_ZERO {
-                        return Err(InvalidDistanceBand(0, bands[0]));
+                        return Err(at!(InvalidDistanceBand(0, bands[0])));
                     }
                     for i in 1..4 {
                         bands[i] = bands[i - 1] * mult(afv_weights[c][i + 5]);
                         if bands[i] < ALMOST_ZERO {
-                            return Err(InvalidDistanceBand(i, bands[i]));
+                            return Err(at!(InvalidDistanceBand(i, bands[i])));
                         }
                     }
 
@@ -1104,7 +1105,7 @@ impl DequantMatrices {
         // Convert weights in place to the final table format (1.0 / weight)
         for weight in &mut weights {
             if !(ALMOST_ZERO..=1.0 / ALMOST_ZERO).contains(weight) {
-                return Err(InvalidQuantizationTableWeight(*weight));
+                return Err(at!(InvalidQuantizationTableWeight(*weight)));
             }
             *weight = 1f32 / *weight;
         }
@@ -1196,12 +1197,12 @@ fn get_quant_weights(
         let mut bands = [0f32; DctQuantWeightParams::MAX_DISTANCE_BANDS];
         bands[0] = distance_bands.params[c][0];
         if bands[0] < ALMOST_ZERO {
-            return Err(InvalidDistanceBand(0, bands[0]));
+            return Err(at!(InvalidDistanceBand(0, bands[0])));
         }
         for i in 1..distance_bands.num_bands {
             bands[i] = bands[i - 1] * mult(distance_bands.params[c][i]);
             if bands[i] < ALMOST_ZERO {
-                return Err(InvalidDistanceBand(i, bands[i]));
+                return Err(at!(InvalidDistanceBand(i, bands[i])));
             }
         }
         let scale = (distance_bands.num_bands - 1) as f32 / (SQRT_2 + 1e-6);

--- a/zenjxl-decoder/src/frame/quantizer.rs
+++ b/zenjxl-decoder/src/frame/quantizer.rs
@@ -9,6 +9,7 @@ use crate::{
     frame::quant_weights,
     headers::encodings::{Empty, UnconditionalCoder},
 };
+use whereat::at;
 
 pub const NUM_QUANT_TABLES: usize = 17;
 pub const GLOBAL_SCALE_DENOM: usize = 1 << 16;
@@ -29,7 +30,7 @@ impl LfQuantFactors {
             for qf in quant_factors.iter_mut() {
                 *qf = f32::read_unconditional(&(), br, &Empty {})? / 128.0;
                 if *qf < 1e-8 {
-                    return Err(Error::LfQuantFactorTooSmall(*qf));
+                    return Err(at!(Error::LfQuantFactorTooSmall(*qf)));
                 }
             }
         }

--- a/zenjxl-decoder/src/frame/render.rs
+++ b/zenjxl-decoder/src/frame/render.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use crate::api::JxlCms;
+use whereat::at;
 use crate::api::JxlColorEncoding;
 use crate::api::JxlColorProfile;
 use crate::api::JxlColorType;
@@ -120,10 +121,10 @@ impl Frame {
                 .get(k_ec_idx)
                 .is_some_and(|f| f.is_some())
             {
-                return Err(Error::CmsConsumedChannelRequested {
+                return Err(at!(Error::CmsConsumedChannelRequested {
                     channel_index: k_ec_idx,
                     channel_type: "Black".to_string(),
-                });
+                }));
             }
         }
         Ok(())
@@ -1786,10 +1787,10 @@ impl Frame {
             )?;
             // CMS cannot add channels - reject transforms that would
             if out_channels > in_channels {
-                return Err(Error::CmsChannelCountIncrease {
+                return Err(at!(Error::CmsChannelCountIncrease {
                     in_channels,
                     out_channels,
-                });
+                }));
             }
             // Only pass black_channel to CmsStage if CMS is actually processing CMYK input.
             // For XYB images, even if original was CMYK, CMS input is linear RGB.
@@ -2003,7 +2004,7 @@ impl Frame {
             let source_alpha_associated =
                 alpha_channel_info.is_some_and(|(_, info)| info.alpha_associated());
             if pixel_format.color_type.is_grayscale() && num_color_channels == 3 {
-                return Err(Error::NotGrayscale);
+                return Err(at!(Error::NotGrayscale));
             }
             // Determine if we need to fill opaque alpha:
             // - color_type requests alpha (has_alpha() is true)

--- a/zenjxl-decoder/src/headers/encodings.rs
+++ b/zenjxl-decoder/src/headers/encodings.rs
@@ -183,11 +183,17 @@ impl UnconditionalCoder<()> for Permutation {
     ) -> Result<Permutation, Error> {
         // TODO: This is quadratic when incrementally parsing byte by byte,
         // we might want to find a better way of reading the permutation.
+        // This trait method returns a bare `Error` (the `UnconditionalCoder`
+        // contract), while the entropy-decode helpers it calls return
+        // `At<Error>`; bridge by taking the owned inner error. A fresh
+        // `whereat` trace is started at the caller via the blanket `From`.
         let ret = if nonserialized.permuted {
             let size = nonserialized.num_entries;
             let num_contexts = 8;
-            let histograms = Histograms::decode(num_contexts, br, /*allow_lz77=*/ true)?;
-            let mut reader = SymbolReader::new(&histograms, br, None)?;
+            let histograms = Histograms::decode(num_contexts, br, /*allow_lz77=*/ true)
+                .map_err(|e| e.decompose().0)?;
+            let mut reader =
+                SymbolReader::new(&histograms, br, None).map_err(|e| e.decompose().0)?;
             Permutation::decode(
                 size,
                 0,
@@ -196,6 +202,7 @@ impl UnconditionalCoder<()> for Permutation {
                 &mut reader,
                 &crate::util::MemoryTracker::default(),
             )
+            .map_err(|e| e.decompose().0)
         } else {
             Ok(Permutation::default())
         };

--- a/zenjxl-decoder/src/headers/modular.rs
+++ b/zenjxl-decoder/src/headers/modular.rs
@@ -140,7 +140,7 @@ pub struct Transform {
 }
 
 impl Transform {
-    fn check(&self, _: &encodings::Empty) -> Result<()> {
+    fn check(&self, _: &encodings::Empty) -> Result<(), Error> {
         if self.id == TransformId::Invalid {
             return Err(Error::InvalidTransformId);
         }

--- a/zenjxl-decoder/src/headers/permutation.rs
+++ b/zenjxl-decoder/src/headers/permutation.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use std::borrow::Cow;
+use whereat::at;
 
 use crate::bit_reader::BitReader;
 use crate::entropy_coding::decode::Histograms;
@@ -50,37 +51,37 @@ impl Permutation {
         mut read: impl FnMut(usize) -> Result<u32>,
     ) -> Result<Self> {
         if end > size - skip {
-            return Err(Error::InvalidPermutationSize { size, skip, end });
+            return Err(at!(Error::InvalidPermutationSize { size, skip, end }));
         }
 
         // Check memory budget for permutation allocations (lehmer + permutation vectors)
         memory_tracker.check_alloc((size as u64) * 4)?;
-        let mut lehmer = Vec::new_with_capacity(end as usize)?;
+        let mut lehmer = Vec::new_with_capacity(end as usize).map_err(|e| at!(Error::from(e)))?;
 
         let mut prev_val = 0u32;
         for idx in skip..(skip + end) {
             let val = match read(get_context(prev_val)) {
                 Ok(val) => val,
-                Err(Error::OutOfBounds(_)) => {
+                Err(e) if matches!(e.error(), Error::OutOfBounds(_)) => {
                     // Estimate 1.5 bits for each remaining code
                     let bits = (((skip + end) - idx) as usize).saturating_mul(3) / 2;
-                    return Err(Error::OutOfBounds(bits));
+                    return Err(at!(Error::OutOfBounds(bits)));
                 }
                 Err(e) => return Err(e),
             };
             if val >= size - idx {
-                return Err(Error::InvalidPermutationLehmerCode {
+                return Err(at!(Error::InvalidPermutationLehmerCode {
                     size,
                     idx,
                     lehmer: val,
-                });
+                }));
             }
             lehmer.push(val);
             prev_val = val;
         }
 
         // Initialize the full permutation vector with skipped elements intact
-        let mut permutation = Vec::new_with_capacity((size - skip) as usize)?;
+        let mut permutation = Vec::new_with_capacity((size - skip) as usize).map_err(|e| at!(Error::from(e)))?;
         permutation.extend(0..size);
 
         // Decode the Lehmer code into the slice starting at `skip`
@@ -110,20 +111,20 @@ impl Permutation {
 fn decode_lehmer_code(code: &[u32], permutation_slice: &[u32]) -> Result<Vec<u32>> {
     let n = permutation_slice.len();
     if n == 0 {
-        return Err(Error::InvalidPermutationLehmerCode {
+        return Err(at!(Error::InvalidPermutationLehmerCode {
             size: 0,
             idx: 0,
             lehmer: 0,
-        });
+        }));
     }
 
-    let mut permuted = Vec::new_with_capacity(n)?;
+    let mut permuted = Vec::new_with_capacity(n).map_err(|e| at!(Error::from(e)))?;
     permuted.extend_from_slice(permutation_slice);
 
     let padded_n = (n as u32).next_power_of_two() as usize;
 
     // Allocate temp array inside the function
-    let mut temp = Vec::new_with_capacity(padded_n)?;
+    let mut temp = Vec::new_with_capacity(padded_n).map_err(|e| at!(Error::from(e)))?;
     temp.extend((0..padded_n as u32).map(|x| value_of_lowest_1_bit(x + 1)));
 
     for (i, permuted_item) in permuted.iter_mut().enumerate() {
@@ -131,11 +132,11 @@ fn decode_lehmer_code(code: &[u32], permutation_slice: &[u32]) -> Result<Vec<u32
 
         // Adjust the maximum allowed value for code_i
         if code_i as usize > n - i - 1 {
-            return Err(Error::InvalidPermutationLehmerCode {
+            return Err(at!(Error::InvalidPermutationLehmerCode {
                 size: n as u32,
                 idx: i as u32,
                 lehmer: code_i,
-            });
+            }));
         }
 
         let mut rank = code_i + 1;
@@ -146,11 +147,11 @@ fn decode_lehmer_code(code: &[u32], permutation_slice: &[u32]) -> Result<Vec<u32
         while bit != 0 {
             let cand = next + bit;
             if cand == 0 || cand > padded_n {
-                return Err(Error::InvalidPermutationLehmerCode {
+                return Err(at!(Error::InvalidPermutationLehmerCode {
                     size: n as u32,
                     idx: i as u32,
                     lehmer: code_i,
-                });
+                }));
             }
             bit >>= 1;
             if temp[cand - 1] < rank {
@@ -176,34 +177,34 @@ fn decode_lehmer_code(code: &[u32], permutation_slice: &[u32]) -> Result<Vec<u32
 fn decode_lehmer_code_naive(code: &[u32], permutation_slice: &[u32]) -> Result<Vec<u32>> {
     let n = code.len();
     if n == 0 {
-        return Err(Error::InvalidPermutationLehmerCode {
+        return Err(at!(Error::InvalidPermutationLehmerCode {
             size: 0,
             idx: 0,
             lehmer: 0,
-        });
+        }));
     }
 
     // Ensure permutation_slice has sufficient length
     if permutation_slice.len() < n {
-        return Err(Error::InvalidPermutationLehmerCode {
+        return Err(at!(Error::InvalidPermutationLehmerCode {
             size: n as u32,
             idx: 0,
             lehmer: 0,
-        });
+        }));
     }
 
     // Create temp array with values from permutation_slice
     let mut temp = permutation_slice.to_vec();
-    let mut permuted = Vec::new_with_capacity(n)?;
+    let mut permuted = Vec::new_with_capacity(n).map_err(|e| at!(Error::from(e)))?;
 
     // Iterate over the Lehmer code
     for (i, &idx) in code.iter().enumerate() {
         if idx as usize >= temp.len() {
-            return Err(Error::InvalidPermutationLehmerCode {
+            return Err(at!(Error::InvalidPermutationLehmerCode {
                 size: n as u32,
                 idx: i as u32,
                 lehmer: idx,
-            });
+            }));
         }
 
         // Assign temp[idx] to permuted vector

--- a/zenjxl-decoder/src/headers/toc.rs
+++ b/zenjxl-decoder/src/headers/toc.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use jxl_macros::UnconditionalCoder;
+use whereat::at;
 
 use crate::{
     bit_reader::BitReader,
@@ -45,7 +46,7 @@ impl IncrementalTocReader {
     pub fn new(num_entries: u32, br: &mut BitReader) -> Result<Self> {
         let permuted = bool::read_unconditional(&(), br, &Empty {})?;
         let mut entries = Vec::new();
-        entries.try_reserve(num_entries as usize)?;
+        entries.try_reserve(num_entries as usize).map_err(|e| at!(Error::from(e)))?;
         Ok(Self {
             num_entries,
             permuted,

--- a/zenjxl-decoder/src/icc/header.rs
+++ b/zenjxl-decoder/src/icc/header.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use crate::{error::Result, util::NewWithCapacity};
+use whereat::at;
 
 use super::{ICC_HEADER_SIZE, IccStream};
 
@@ -40,7 +41,7 @@ pub(super) fn read_header(data_stream: &mut IccStream, output_size: u64) -> Resu
     let header_size = output_size.min(ICC_HEADER_SIZE);
     let header_data = data_stream.read_to_vec_exact(header_size as usize)?;
 
-    let mut profile = Vec::new_with_capacity(output_size as usize)?;
+    let mut profile = Vec::new_with_capacity(output_size as usize).map_err(|e| at!(crate::error::Error::from(e)))?;
 
     for (idx, &e) in header_data.iter().enumerate() {
         let p = predict_header(idx, output_size as u32, &header_data);

--- a/zenjxl-decoder/src/icc/mod.rs
+++ b/zenjxl-decoder/src/icc/mod.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use std::io::Cursor;
+use whereat::at;
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
@@ -27,20 +28,20 @@ use tag::{read_single_command, read_tag_list};
 const ICC_CONTEXTS: usize = 41;
 const ICC_HEADER_SIZE: u64 = 128;
 
-fn read_icc_inner(stream: &mut IccStream) -> Result<Vec<u8>, Error> {
+fn read_icc_inner(stream: &mut IccStream) -> Result<Vec<u8>> {
     let output_size = stream.read_varint()?;
     let commands_size = stream.read_varint()?;
     if stream.bytes_read().saturating_add(commands_size) > stream.len() {
-        return Err(Error::InvalidIccStream);
+        return Err(at!(Error::InvalidIccStream));
     }
 
     // Simple check to avoid allocating too large buffer.
     if output_size > (1 << 28) {
-        return Err(Error::IccTooLarge);
+        return Err(at!(Error::IccTooLarge));
     }
 
     if output_size + 65536 < stream.len() {
-        return Err(Error::IccTooLarge);
+        return Err(at!(Error::IccTooLarge));
     }
 
     // Extract command stream first.
@@ -67,7 +68,7 @@ fn read_icc_inner(stream: &mut IccStream) -> Result<Vec<u8>, Error> {
     if let Some(num_tags) = v.checked_sub(1) {
         if (output_size - ICC_HEADER_SIZE) / 12 < num_tags {
             warn!(output_size, num_tags, "num_tags too large");
-            return Err(Error::InvalidIccStream);
+            return Err(at!(Error::InvalidIccStream));
         }
 
         let num_tags = num_tags as u32;
@@ -99,7 +100,7 @@ fn read_icc_inner(stream: &mut IccStream) -> Result<Vec<u8>, Error> {
     let actual_len = decoded_profile_writer.position();
     if actual_len != output_size {
         warn!(output_size, actual_len, "ICC profile size mismatch");
-        return Err(Error::InvalidIccStream);
+        return Err(at!(Error::InvalidIccStream));
     }
 
     Ok(decoded_profile)
@@ -128,11 +129,11 @@ impl IncrementalIccReader {
         // Use provided limit or fall back to default 256MB
         let limit = max_icc_size.unwrap_or(1 << 28) as u64;
         if len > limit {
-            return Err(Error::LimitExceeded {
+            return Err(at!(Error::LimitExceeded {
                 resource: "icc_size",
                 actual: len,
                 limit,
-            });
+            }));
         }
 
         let len = len as usize;
@@ -144,7 +145,7 @@ impl IncrementalIccReader {
             histograms,
             reader,
             len,
-            out_buf: Vec::new_with_capacity(len)?,
+            out_buf: Vec::new_with_capacity(len).map_err(|e| at!(Error::from(e)))?,
             prev_bytes: [0, 0],
             total_bits_consumed: 0,
             last_br_bits_read,
@@ -200,11 +201,11 @@ impl IncrementalIccReader {
 
         if let Err(err) = br.check_for_error() {
             self.reader.restore(checkpoint);
-            return Err(err);
+            return Err(at!(err));
         }
         if sym >= 256 {
             warn!(sym, "Invalid symbol in ICC stream");
-            return Err(Error::InvalidIccStream);
+            return Err(at!(Error::InvalidIccStream));
         }
 
         let b = sym as u8;
@@ -231,11 +232,11 @@ impl IncrementalIccReader {
         if self.out_buf.len() & 0xFF == 0 {
             let input_bytes = (self.total_bits_consumed / 8 + 1) as usize;
             if self.out_buf.len() / input_bytes > Self::MAX_AMPLIFICATION {
-                return Err(Error::LimitExceeded {
+                return Err(at!(Error::LimitExceeded {
                     resource: "icc_amplification",
                     actual: self.out_buf.len() as u64,
                     limit: (input_bytes * Self::MAX_AMPLIFICATION) as u64,
-                });
+                }));
             }
         }
         Ok(())

--- a/zenjxl-decoder/src/icc/stream.rs
+++ b/zenjxl-decoder/src/icc/stream.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use std::io::{Read, Write};
+use whereat::at;
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
@@ -26,7 +27,7 @@ fn read_varint(mut read_one: impl FnMut() -> Result<u8>) -> Result<u64> {
 }
 
 pub(crate) fn read_varint_from_reader(stream: &mut impl Read) -> Result<u64> {
-    read_varint(|| stream.read_u8().map_err(|_| Error::IccEndOfStream))
+    read_varint(|| stream.read_u8().map_err(|_| at!(Error::IccEndOfStream)))
 }
 
 pub(super) struct IccStream {
@@ -56,7 +57,7 @@ impl IccStream {
 
     fn read_one(&mut self) -> Result<u8> {
         if self.remaining_bytes() == 0 {
-            return Err(Error::IccEndOfStream);
+            return Err(at!(Error::IccEndOfStream));
         }
         self.bytes_read += 1;
         Ok(self.command_stream[self.bytes_read as usize - 1])
@@ -64,7 +65,7 @@ impl IccStream {
 
     pub fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
         if buf.len() > self.remaining_bytes() as usize {
-            return Err(Error::IccEndOfStream);
+            return Err(at!(Error::IccEndOfStream));
         }
 
         for b in buf {
@@ -76,10 +77,10 @@ impl IccStream {
 
     pub fn read_to_vec_exact(&mut self, len: usize) -> Result<Vec<u8>> {
         if len > self.remaining_bytes() as usize {
-            return Err(Error::IccEndOfStream);
+            return Err(at!(Error::IccEndOfStream));
         }
 
-        let mut out = Vec::new_with_capacity(len)?;
+        let mut out = Vec::new_with_capacity(len).map_err(|e| at!(Error::from(e)))?;
 
         for _ in 0..len {
             out.push(self.read_one()?);
@@ -94,7 +95,7 @@ impl IccStream {
 
     pub fn copy_bytes(&mut self, writer: &mut impl Write, len: usize) -> Result<()> {
         if len > self.remaining_bytes() as usize {
-            return Err(Error::IccEndOfStream);
+            return Err(at!(Error::IccEndOfStream));
         }
 
         for _ in 0..len {
@@ -112,7 +113,7 @@ impl IccStream {
             Ok(())
         } else {
             warn!("ICC stream is not fully consumed");
-            Err(Error::InvalidIccStream)
+            Err(at!(Error::InvalidIccStream))
         }
     }
 }

--- a/zenjxl-decoder/src/icc/tag.rs
+++ b/zenjxl-decoder/src/icc/tag.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use std::io::{Cursor, Write};
+use whereat::at;
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
@@ -47,7 +48,7 @@ pub(super) fn read_tag_list(
                 tag
             }
             2..=20 => *COMMON_TAGS[(tagcode - 2) as usize],
-            _ => return Err(Error::InvalidIccStream),
+            _ => return Err(at!(Error::InvalidIccStream)),
         };
 
         let tagstart = if command & 64 == 0 {
@@ -64,7 +65,7 @@ pub(super) fn read_tag_list(
         };
         if (tagstart as u64 + tagsize as u64) > output_size {
             warn!(output_size, tagstart, tagsize, "tag size overflow");
-            return Err(Error::InvalidIccStream);
+            return Err(at!(Error::InvalidIccStream));
         }
 
         prev_tagstart = tagstart;
@@ -106,7 +107,7 @@ pub(super) fn read_tag_list(
 
 fn shuffle_w2(bytes: &[u8]) -> Result<Vec<u8>> {
     let len = bytes.len();
-    let mut out = Vec::new_with_capacity(len)?;
+    let mut out = Vec::new_with_capacity(len).map_err(|e| at!(Error::from(e)))?;
 
     let height = len / 2;
     let odd = len % 2;
@@ -122,7 +123,7 @@ fn shuffle_w2(bytes: &[u8]) -> Result<Vec<u8>> {
 
 fn shuffle_w4(bytes: &[u8]) -> Result<Vec<u8>> {
     let len = bytes.len();
-    let mut out = Vec::new_with_capacity(len)?;
+    let mut out = Vec::new_with_capacity(len).map_err(|e| at!(Error::from(e)))?;
 
     let step = len / 4;
     let wide_count = len % 4;
@@ -175,7 +176,7 @@ pub(super) fn read_single_command(
             let width = ((flags & 3) + 1) as usize;
             let order = (flags >> 2) & 3;
             if width == 3 || order == 3 {
-                return Err(Error::InvalidIccStream);
+                return Err(at!(Error::InvalidIccStream));
             }
 
             let stride = if (flags & 16) == 0 {
@@ -183,12 +184,12 @@ pub(super) fn read_single_command(
             } else {
                 let stride = read_varint_from_reader(commands_stream)? as usize;
                 if stride < width {
-                    return Err(Error::InvalidIccStream);
+                    return Err(at!(Error::InvalidIccStream));
                 }
                 stride
             };
             if stride.saturating_mul(4) >= decoded_profile.position() as usize {
-                return Err(Error::InvalidIccStream);
+                return Err(at!(Error::InvalidIccStream));
             }
 
             let num = read_varint_from_reader(commands_stream)? as usize;
@@ -243,7 +244,7 @@ pub(super) fn read_single_command(
                 .map_err(|_| Error::InvalidIccStream)?;
         }
         _ => {
-            return Err(Error::InvalidIccStream);
+            return Err(at!(Error::InvalidIccStream));
         }
     }
 

--- a/zenjxl-decoder/src/image/internal.rs
+++ b/zenjxl-decoder/src/image/internal.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use std::fmt::Debug;
+use whereat::at;
 
 use crate::{
     error::{Error, Result},
@@ -164,7 +165,7 @@ impl RawImageBuffer {
             });
         }
         if bytes_per_row as u64 >= i64::MAX as u64 / 4 || num_rows as u64 >= i64::MAX as u64 / 4 {
-            return Err(Error::ImageSizeTooLarge(bytes_per_row, num_rows));
+            return Err(at!(Error::ImageSizeTooLarge(bytes_per_row, num_rows)));
         }
         debug!("trying to allocate image");
         let bytes_between_rows =

--- a/zenjxl-decoder/src/lib.rs
+++ b/zenjxl-decoder/src/lib.rs
@@ -57,6 +57,11 @@
 #![cfg_attr(not(feature = "allow-unsafe"), forbid(unsafe_code))]
 #![cfg_attr(feature = "allow-unsafe", deny(unsafe_code))]
 
+// Enables `at!()` source-location tracking (`whereat`) and clickable GitHub
+// links in error traces. The `path` matches this crate's location within the
+// repository so the generated blob URLs resolve correctly.
+whereat::define_at_crate_info!(path = "zenjxl-decoder/");
+
 pub mod api;
 pub use api::{decode, decode_with, read_header, read_header_with};
 #[cfg(feature = "jpeg")]

--- a/zenjxl-decoder/src/render/builder.rs
+++ b/zenjxl-decoder/src/render/builder.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use crate::api::{JxlColorType, JxlDataFormat};
+use whereat::at;
 use crate::error::{Error, Result};
 use crate::headers::Orientation;
 use crate::render::StageSpecialCase;
@@ -212,12 +213,12 @@ impl<Pipeline: RenderPipeline> RenderPipelineBuilder<Pipeline> {
                     if let Some(ty) = info.ty
                         && ty != input_type
                     {
-                        return Err(Error::PipelineChannelTypeMismatch(
+                        return Err(at!(Error::PipelineChannelTypeMismatch(
                             stage.to_string(),
                             c,
                             input_type,
                             ty,
-                        ));
+                        )));
                     }
                     after_info.push(ChannelInfo {
                         ty: Some(output_type.unwrap_or(input_type)),
@@ -228,7 +229,7 @@ impl<Pipeline: RenderPipeline> RenderPipelineBuilder<Pipeline> {
             if self.shared.extend_stage_index.is_some()
                 && (shift != (0, 0) || border != (0, 0) || is_extend)
             {
-                return Err(Error::PipelineInvalidStageAfterExtend(stage.to_string()));
+                return Err(at!(Error::PipelineInvalidStageAfterExtend(stage.to_string())));
             }
             if is_extend {
                 self.shared.extend_stage_index = Some(i);
@@ -268,10 +269,10 @@ impl<Pipeline: RenderPipeline> RenderPipelineBuilder<Pipeline> {
                     && save_downsample.is_some_and(|x| x != *cur_downsample)
                 {
                     save_downsample = Some(*cur_downsample);
-                    return Err(Error::SaveDifferentDownsample(
+                    return Err(at!(Error::SaveDifferentDownsample(
                         save_downsample.unwrap(),
                         *cur_downsample,
-                    ));
+                    )));
                 }
                 let next_downsample = &mut next_chan.downsample;
                 let next_total_downsample = *cur_downsample;

--- a/zenjxl-decoder/src/render/low_memory_pipeline/row_buffers.rs
+++ b/zenjxl-decoder/src/render/low_memory_pipeline/row_buffers.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use std::ops::Range;
+use whereat::at;
 
 use crate::{
     error::Result,
@@ -43,7 +44,7 @@ impl RowBuffer {
         let row_stride =
             (row_len * data_type.size()).div_ceil(CACHE_LINE_BYTE_SIZE) + (3 << x_shift);
         let mut buffer = Vec::<CacheLine>::new();
-        buffer.try_reserve_exact(row_stride * num_rows)?;
+        buffer.try_reserve_exact(row_stride * num_rows).map_err(|e| at!(crate::error::Error::from(e)))?;
         buffer.resize(row_stride * num_rows, CacheLine::default());
         let buffer = buffer.into_boxed_slice();
         Ok(Self {

--- a/zenjxl-decoder/src/render/save.rs
+++ b/zenjxl-decoder/src/render/save.rs
@@ -9,6 +9,7 @@ use crate::{
     headers::Orientation,
     image::DataTypeTag,
 };
+use whereat::at;
 
 #[derive(Debug)]
 pub struct SaveStage {
@@ -76,14 +77,14 @@ impl SaveStage {
         let expected_w = self.output_channels() * self.data_format.bytes_per_sample() * osize.0;
 
         if buf.byte_size() != (expected_w, osize.1) {
-            return Err(Error::InvalidOutputBufferSize(
+            return Err(at!(Error::InvalidOutputBufferSize(
                 buf.byte_size().0,
                 buf.byte_size().1,
                 osize.0,
                 osize.1,
                 self.color_type,
                 self.data_format,
-            ));
+            )));
         }
         Ok(())
     }

--- a/zenjxl-decoder/src/render/stages/patches.rs
+++ b/zenjxl-decoder/src/render/stages/patches.rs
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 use std::{any::Any, sync::Arc};
+use whereat::at;
 
 use crate::{
     features::patches::PatchesDictionary, frame::ReferenceFrame,
@@ -52,7 +53,7 @@ impl RenderPipelineInPlaceStage for PatchesStage {
         &self,
         _thread_index: usize,
     ) -> crate::error::Result<Option<Box<dyn Any + Send>>> {
-        let patches_for_row_result = Vec::<usize>::new_with_capacity(self.patches.positions.len())?;
+        let patches_for_row_result = Vec::<usize>::new_with_capacity(self.patches.positions.len()).map_err(|e| at!(crate::error::Error::from(e)))?;
         Ok(Some(Box::new(patches_for_row_result) as Box<dyn Any + Send>))
     }
 }

--- a/zenjxl-decoder/src/tests/decode_api.rs
+++ b/zenjxl-decoder/src/tests/decode_api.rs
@@ -11,11 +11,13 @@
 use crate::api::{
     JxlDecoder, JxlDecoderOptions, JxlSignatureType, ProcessingResult, check_signature, states,
 };
+use whereat::at;
+use crate::error::Result;
 
 /// Helper to process decoder to WithImageInfo state
 fn process_to_image_info(
     data: &[u8],
-) -> Result<crate::api::JxlDecoder<states::WithImageInfo>, crate::error::Error> {
+) -> Result<crate::api::JxlDecoder<states::WithImageInfo>> {
     let options = JxlDecoderOptions::default();
     let mut decoder = JxlDecoder::<states::Initialized>::new(options);
     let mut input = data;
@@ -26,7 +28,7 @@ fn process_to_image_info(
             ProcessingResult::NeedsMoreInput { fallback, .. } => {
                 // If input is exhausted but decoder needs more, that's a truncation error
                 if input.is_empty() {
-                    return Err(crate::error::Error::OutOfBounds(0));
+                    return Err(at!(crate::error::Error::OutOfBounds(0)));
                 }
                 decoder = fallback;
             }

--- a/zenjxl-decoder/src/tests/reject_progressive.rs
+++ b/zenjxl-decoder/src/tests/reject_progressive.rs
@@ -45,7 +45,7 @@ fn progressive_multipass_rejected_when_gate_set() {
         Ok(_) => {
             panic!("progressive (num_passes=3) frame must be rejected when reject_progressive=true")
         }
-        Err(Error::ProgressiveRejected) => {}
+        Err(e) if matches!(e.error(), Error::ProgressiveRejected) => {}
         Err(other) => panic!("expected Error::ProgressiveRejected, got {other:?}"),
     }
 }

--- a/zenjxl-decoder/src/tests/streaming.rs
+++ b/zenjxl-decoder/src/tests/streaming.rs
@@ -10,6 +10,8 @@
 //! DO NOT WEAKEN TOLERANCES or modify tests to pass when implementation is wrong.
 
 use crate::api::{JxlDecoder, JxlDecoderOptions, ProcessingResult, states};
+use whereat::at;
+use crate::error::Result;
 
 fn test_resources_dir() -> std::path::PathBuf {
     let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -17,7 +19,7 @@ fn test_resources_dir() -> std::path::PathBuf {
 }
 
 /// Helper to decode a JXL file with all data at once
-fn decode_oneshot(data: &[u8]) -> Result<JxlDecoder<states::WithImageInfo>, crate::error::Error> {
+fn decode_oneshot(data: &[u8]) -> Result<JxlDecoder<states::WithImageInfo>> {
     let options = JxlDecoderOptions::default();
     let mut decoder = JxlDecoder::<states::Initialized>::new(options);
     let mut input = data;
@@ -27,7 +29,7 @@ fn decode_oneshot(data: &[u8]) -> Result<JxlDecoder<states::WithImageInfo>, crat
             ProcessingResult::Complete { result } => return Ok(result),
             ProcessingResult::NeedsMoreInput { fallback, .. } => {
                 if input.is_empty() {
-                    return Err(crate::error::Error::OutOfBounds(0));
+                    return Err(at!(crate::error::Error::OutOfBounds(0)));
                 }
                 decoder = fallback;
             }
@@ -39,7 +41,7 @@ fn decode_oneshot(data: &[u8]) -> Result<JxlDecoder<states::WithImageInfo>, crat
 fn decode_chunked(
     data: &[u8],
     chunk_size: usize,
-) -> Result<JxlDecoder<states::WithImageInfo>, crate::error::Error> {
+) -> Result<JxlDecoder<states::WithImageInfo>> {
     let options = JxlDecoderOptions::default();
     let mut decoder = JxlDecoder::<states::Initialized>::new(options);
     let mut offset = 0;
@@ -56,7 +58,7 @@ fn decode_chunked(
                 offset += consumed;
 
                 if offset >= data.len() {
-                    return Err(crate::error::Error::OutOfBounds(0));
+                    return Err(at!(crate::error::Error::OutOfBounds(0)));
                 }
                 decoder = fallback;
             }

--- a/zenjxl-decoder/src/util/memory_tracker.rs
+++ b/zenjxl-decoder/src/util/memory_tracker.rs
@@ -9,6 +9,7 @@
 //! `max_memory_bytes` limits during decoding.
 
 use std::sync::Arc;
+use whereat::at;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::error::{Error, Result};
@@ -85,11 +86,11 @@ impl MemoryTracker {
         if new_total > inner.limit {
             // Rollback the allocation
             inner.allocated.fetch_sub(bytes, Ordering::Relaxed);
-            return Err(Error::LimitExceeded {
+            return Err(at!(Error::LimitExceeded {
                 resource: "memory_bytes",
                 actual: new_total,
                 limit: inner.limit,
-            });
+            }));
         }
 
         Ok(())
@@ -120,14 +121,14 @@ impl MemoryTracker {
             let Some(inner) = &self.inner else {
                 return Ok(());
             };
-            return Err(Error::LimitExceeded {
+            return Err(at!(Error::LimitExceeded {
                 resource: "memory_bytes",
                 actual: inner
                     .allocated
                     .load(Ordering::Relaxed)
                     .saturating_add(bytes),
                 limit: inner.limit,
-            });
+            }));
         }
         Ok(())
     }

--- a/zenjxl-decoder/src/util/test.rs
+++ b/zenjxl-decoder/src/util/test.rs
@@ -55,6 +55,14 @@ impl From<JXLError> for Error {
     }
 }
 
+// Test helpers propagate the decoder's location-tracked `At<Error>` via `?`;
+// the trace is not needed in test output, so collapse to the inner error.
+impl From<whereat::At<JXLError>> for Error {
+    fn from(value: whereat::At<JXLError>) -> Self {
+        Error::InvalidPFM(value.decompose().0.to_string())
+    }
+}
+
 fn rel_error_gt<T: AsPrimitive<f64>>(left: T, right: T, max_rel_error: T) -> bool {
     let left_f64: f64 = left.as_();
     let right_f64: f64 = right.as_();


### PR DESCRIPTION
## What

Decode errors now carry a `file:line` source location for server-side stack traces — the production-debuggable axis of the audit. Closes #28.

**BREAKING:** the public `Error` is wrapped as `whereat::At<Error>` via the `Result` alias. Get the cause with `e.error()` (borrow `&Error`) or `e.decompose().0` (owned); `into_inner()` is deprecated. `Error` stays `#[non_exhaustive]`.

## How — the careful two-layer split

258 error origins across 46 files are wrapped with `at!()`. The crate has a **two-layer error design** that this preserves:

- **Low-level layer (the hot decode path)** — bitstream / header / ICC / entropy, plus the `#[derive(UnconditionalCoder)]` proc-macro output and the public `JxlBitstreamInput` trait — keeps a **bare `Error`**. `at!()` never appears in a per-coefficient / per-pixel / per-block **inner loop**; it sits only at function-boundary returns, so there's no per-iteration `At<>` allocation in the hot loops.
- **Frame / render / api layer** carries `At<Error>`. whereat's blanket `From<E> for At<E>` bridges the two, so a trace originates at the first bare→alias crossing.

This honours the perf constraint ("don't put `At<>` in inner loops; wrap only out of the hot path") while still capturing locations for the structural/metadata failures that dominate server-facing decode errors on malformed input.

## Verification

- **Correctness: `cargo test --lib` → 1253 passed / 0 failed / 28 ignored — byte-identical to the pre-change baseline** (1253/0). Every `decode_test_file_*` and `compare_pipelines_*` pixel-comparison test (incl. 4K, lossless, JPEG-recompression, animation, HDR) passes unchanged, so decode output is bit-exact.
- `cargo build --lib` + `--tests` + `cargo clippy` clean.
- Diff independently reviewed: only error-wrapping (`at!`/`.map_err(at!)`/`.error()`/`.decompose()`), zero arithmetic / comparison / indexing / control-flow changes (verified in the hot-path files `entropy_coding/ans.rs`, `frame/group.rs`, `frame/modular/tree.rs`).

A `decode_bench` A/B follows in a comment to confirm the per-group/per-frame boundary `At<Error>` adds no measurable cost.

## Notes

- `#28` filed this as the cold-origin chunk; this builds the location capture in directly (no separate boundary PR needed).
- Lockfile diff is only the `whereat` dep (zenjxl-decoder tracks `Cargo.lock`; default features don't pull brotli, so no `alloc-no-stdlib` change).
