### PR TITLE
docs(readme): fix wrong crate name + stale decode example, add error/cancellation guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Maintained by [Lilith River](https://github.com/lilith) at [Imazen](https://gith
 zenjxl-decoder = "0.3"
 ```
 
-The Rust lib name is `jxl`, so you `use jxl::...` in code.
+The Rust lib name is `zenjxl_decoder`, so you `use zenjxl_decoder::...` in code.
 
 If you find a conformant JXL file that decodes incorrectly (or not at all), [open an issue](https://github.com/imazen/zenjxl-decoder/issues/new).
 
@@ -45,23 +45,25 @@ This fork fixes several decoding bugs, adds resource limits and cooperative canc
 ### Basic decode
 
 ```rust
-use jxl::api::{JxlDecoder, JxlDecoderOptions};
+use zenjxl_decoder::decode;
 
 let data = std::fs::read("image.jxl")?;
-let mut decoder = JxlDecoder::new(&data, JxlDecoderOptions::default());
-// ... process frames
+let image = decode(&data)?; // one-shot: bytes -> JxlImage (RGBA8 or GrayAlpha8)
+println!("{}x{}, {} channels", image.width, image.height, image.channels);
+assert_eq!(image.data.len(), image.width * image.height * image.channels);
 ```
 
 ### Resource limits
 
 ```rust
-use jxl::api::{JxlDecoderLimits, JxlDecoderOptions};
+use zenjxl_decoder::{decode_with, api::{JxlDecoderLimits, JxlDecoderOptions}};
 
-// For untrusted input
+// For untrusted input, start from the restrictive preset.
 let options = JxlDecoderOptions {
     limits: JxlDecoderLimits::restrictive(),
     ..Default::default()
 };
+let image = decode_with(&data, options)?;
 ```
 
 | Limit | Default | Restrictive |
@@ -79,7 +81,9 @@ All limits return `Error::LimitExceeded { resource, actual, limit }` when exceed
 
 ### Cancellation
 
-The decoder accepts any [`enough::Stop`](https://docs.rs/enough) implementation:
+The decoder accepts any [`enough::Stop`](https://docs.rs/enough) implementation. The
+ready-made `Stopper` lives in the companion [`almost-enough`](https://crates.io/crates/almost-enough)
+crate — add it with `cargo add almost-enough`:
 
 ```rust
 use almost_enough::Stopper;
@@ -101,6 +105,27 @@ let options = JxlDecoderOptions {
 ```
 
 Cancellation checks run inside parallel closures too, so a cancel request is noticed mid-batch.
+
+### Errors
+
+`decode` / `decode_with` return `zenjxl_decoder::Result<JxlImage>` = `Result<JxlImage, Error>`.
+`Error` is `#[non_exhaustive]`, so keep a wildcard arm. Match the variants to handle
+resource-limit, cancellation, and malformed-input failures differently:
+
+```rust
+use zenjxl_decoder::{decode_with, Error, api::{JxlDecoderLimits, JxlDecoderOptions}};
+
+let options = JxlDecoderOptions { limits: JxlDecoderLimits::restrictive(), ..Default::default() };
+match decode_with(&data, options) {
+    Ok(image) => { /* image.width, image.height, image.data … */ }
+    Err(Error::Cancelled) => { /* a Stop token requested cancellation or timeout */ }
+    Err(Error::LimitExceeded { resource, actual, limit }) => {
+        // reject oversized / hostile input (e.g. HTTP 413)
+        eprintln!("limit '{resource}' exceeded: {actual} > {limit}");
+    }
+    Err(e) => eprintln!("malformed or unsupported JXL: {e}"), // every other variant
+}
+```
 
 ### Parallel decoding
 


### PR DESCRIPTION
## What

Fixes the README so a first-time user can actually compile the examples.

## Why

I ran an **insulated "external developer" test**: an agent given *only* `README.md` + `docs/public-api/zenjxl-decoder.txt` (no source, no hints) was asked to write a server-side decode-with-limits-and-cancellation program. It could not compile anything, because:

| Issue | README said | Reality (verified in source) |
|---|---|---|
| **Wrong crate name** | line 12: "lib name is `jxl`", all examples `use jxl::...` | lib is `zenjxl_decoder` (no `[lib] name` rename) |
| **Stale decode example** | `JxlDecoder::new(&data, options)` | `JxlDecoder::new` takes only `options`; one-shot is `decode(&data)` / `decode_with(&data, options)` |
| **Undeclared cancel dep** | `use almost_enough::Stopper;` | `almost-enough` is a separate crate; needs `cargo add almost-enough` |
| **No error section** | — | added: match `Error::Cancelled` / `LimitExceeded { resource, actual, limit }` / `#[non_exhaustive]` wildcard |

## Verification

Every symbol checked against source: `lib.rs:36` (`pub use error::{Error, Result}`), `lib.rs:61` (`pub use api::{decode, decode_with, …}`), `convenience.rs` (`decode`, `JxlImage{width,height,channels,data}`), `options.rs:163` (`stop: Arc<dyn enough::Stop>`), `error.rs:297–303` (`LimitExceeded`/`Cancelled`). The README is not `include_str!`-compiled, so these are not doctests — correctness rests on the source check above.

Part of a broader doc-quality pass: the same insulated-agent test surfaced two **universal** gaps across the zen codecs (no concrete cancellation-token example; `whereat::At::location()` never shown) — follow-up PRs will address those per-crate.
