### PR TITLE
docs(zenjxl-decoder): add a real decode-to-pixels example + fix limits/cancellation docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ This project is a fork of [libjxl/jxl-rs](https://github.com/libjxl/jxl-rs). The
   (`JxlBasicInfo`) is unchanged — progressive is enforced during decode, not
   surfaced on the probe. (966f9c5)
 
+### Fixed
+- docs(readme): the Basic decode example now shows a real decode-to-pixels flow
+  (`width`/`height`/`data`/`channels` off `JxlImage`) instead of stopping short,
+  and documents the output format (8-bit interleaved RGBA8/GrayAlpha8, straight
+  alpha by default). Corrected the limits table (default `max_pixels` is 2^28
+  ~256M not 2^30; `restrictive()` `max_pixels` is 120M not 100M; default
+  `max_memory_bytes` is 4 GB / 2 GB-on-32-bit, not `None`) and the cancellation
+  section (the `stop` field is `Arc<dyn enough::Stop>` defaulting to the
+  `enough::Unstoppable` no-op; `almost_enough::Stopper` at `0.4` is how you
+  actually cancel). Found by an insulated external-developer usability test.
+
 ## [0.3.10] - 2026-06-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,14 +44,38 @@ This fork fixes several decoding bugs, adds resource limits and cooperative canc
 
 ### Basic decode
 
+`decode` is the one-liner for trusted input. It returns a [`JxlImage`](https://docs.rs/zenjxl-decoder/latest/zenjxl_decoder/api/struct.JxlImage.html)
+whose public fields hold everything you need to get pixels out:
+
 ```rust
 use zenjxl_decoder::decode;
 
 let data = std::fs::read("image.jxl")?;
-let image = decode(&data)?; // one-shot: bytes -> JxlImage (RGBA8 or GrayAlpha8)
-println!("{}x{}, {} channels", image.width, image.height, image.channels);
-assert_eq!(image.data.len(), image.width * image.height * image.channels);
+let image = decode(&data)?; // one-shot: bytes -> JxlImage
+
+let width: usize = image.width;
+let height: usize = image.height;
+let pixels: &[u8] = &image.data; // interleaved, row-major, tightly packed
+let channels: usize = image.channels; // 4 = RGBA, 2 = GrayAlpha
+
+println!("{width}x{height}, {channels} channels, {} bytes", pixels.len());
+assert_eq!(image.data.len(), width * height * channels);
 ```
+
+**Output format.** `decode` / `decode_with` always emit **8-bit interleaved**
+pixels with an alpha channel: `RGBA8` (4 channels) for color images, or
+`GrayAlpha8` (2 channels) when `image.is_grayscale` is `true`. Images without a
+source alpha channel get an opaque `255` alpha. Alpha is **straight (not
+premultiplied)** by default — set `premultiply_output: true` on
+`JxlDecoderOptions` if you want premultiplied output for compositing. Pixels are
+in the output color profile (`image.output_profile`); for XYB/wide-gamut sources
+this is sRGB with the sRGB transfer function applied, so HDR/float values are
+range-mapped into u8, not returned as floats. Only the first frame is decoded;
+for animation use the streaming `JxlDecoder` API.
+
+`decode` uses the default security limits — note `max_pixels` defaults to ~256
+megapixels, which is **not** as tight as the `restrictive()` preset below. For
+untrusted input, prefer `decode_with` + `restrictive()`.
 
 ### Resource limits
 
@@ -68,43 +92,57 @@ let image = decode_with(&data, options)?;
 
 | Limit | Default | Restrictive |
 |-------|---------|-------------|
-| `max_pixels` | 2^30 (~1B) | 100M |
+| `max_pixels` | 2^28 (~256M) | 120M |
 | `max_extra_channels` | 256 | 16 |
 | `max_icc_size` | 256 MB | 1 MB |
 | `max_tree_size` | 4M nodes | 1M nodes |
 | `max_patches` | (derived) | 64K |
 | `max_spline_points` | 1M | 64K |
 | `max_reference_frames` | 4 | 2 |
-| `max_memory_bytes` | None | 1 GB |
+| `max_memory_bytes` | 4 GB (2 GB on 32-bit) | 1 GB |
 
-All limits return `Error::LimitExceeded { resource, actual, limit }` when exceeded.
+`unlimited()` sets every field to `None`. All limits return
+`Error::LimitExceeded { resource, actual, limit }` when exceeded.
 
 ### Cancellation
 
-The decoder accepts any [`enough::Stop`](https://docs.rs/enough) implementation. The
-ready-made `Stopper` lives in the companion [`almost-enough`](https://crates.io/crates/almost-enough)
-crate — add it with `cargo add almost-enough`:
+The `stop` field on `JxlDecoderOptions` is an
+`Arc<dyn `[`enough::Stop`](https://docs.rs/enough)`>`. It defaults to
+`Arc::new(enough::Unstoppable)` — the no-op handle from the
+[`enough`](https://crates.io/crates/enough) crate (a transitive dependency, so
+you do not need to add it) — which never cancels.
+
+To *actually* cancel or time out a decode, use the ready-made `Stopper` from the
+companion [`almost-enough`](https://crates.io/crates/almost-enough) crate. Both
+are at `0.4`; add the constructible one with `cargo add almost-enough`:
+
+```toml
+[dependencies]
+almost-enough = "0.4"
+```
 
 ```rust
 use almost_enough::Stopper;
 use std::sync::Arc;
 
-let stop = Arc::new(Stopper::new());
+let stop = Arc::new(Stopper::new()); // Arc<Stopper> coerces to Arc<dyn enough::Stop>
 let stop_clone = Arc::clone(&stop);
 
-// Cancel from another thread
+// Cancel from another thread (e.g. a request timeout)
 std::thread::spawn(move || {
     std::thread::sleep(std::time::Duration::from_secs(5));
     stop_clone.cancel();
 });
 
 let options = JxlDecoderOptions {
-    stop,
+    stop, // overrides the default enough::Unstoppable no-op
     ..Default::default()
 };
+let image = decode_with(&data, options)?;
 ```
 
-Cancellation checks run inside parallel closures too, so a cancel request is noticed mid-batch.
+A cancelled decode returns `Err(Error::Cancelled)`. Cancellation checks run
+inside the parallel closures too, so a cancel request is noticed mid-batch.
 
 ### Errors
 


### PR DESCRIPTION
An insulated external-developer usability test (an agent given **only** the README, no source) flagged the README's biggest gap: it didn't show how to get a single pixel or dimension out of a decode. The earlier `// ... process frames` snippet stopped at decoder configuration, and the cancellation example contradicted its own prose. This PR fixes the README against the actual source API (`src/api/convenience.rs`, `src/api/options.rs`, `src/error.rs`).

### Basic decode — now a complete decode-to-pixels flow
The example reads bytes, calls `decode(&data)?`, and pulls real fields off `JxlImage`: `width`, `height`, `data` (`&[u8]`), `channels` — printing dims + byte count and asserting `data.len() == width * height * channels`.

### Output format — stated explicitly (was a silent-corruption risk for servers)
`decode` / `decode_with` always emit **8-bit interleaved** pixels with alpha: `RGBA8` (4ch) or `GrayAlpha8` (2ch when `is_grayscale`), opaque 255 alpha when the source has none, **straight (not premultiplied)** by default (`premultiply_output: true` opts in). XYB/wide-gamut sources are sRGB-mapped into u8 — not returned as float/HDR. Only the first frame is decoded.

### Limits table — corrected to match `src/api/options.rs`
- default `max_pixels`: ~~2^30 (~1B)~~ → **2^28 (~256M)** (`options.rs:74`)
- restrictive `max_pixels`: ~~100M~~ → **120M** (`options.rs:105`, raised in #33)
- default `max_memory_bytes`: ~~None~~ → **4 GB (2 GB on 32-bit)** (`options.rs:64-72,81`)
- noted `unlimited()` sets every field to `None`

### Cancellation — resolved the prose-vs-code contradiction
The `stop` field is `Arc<dyn enough::Stop>` (`options.rs:163`), defaulting to `Arc::new(enough::Unstoppable)` — the no-op from `enough` (transitive dep). To actually cancel, use `almost_enough::Stopper::new()` + `.cancel()` from the companion `almost-enough` crate. Both deps are at `0.4`; the section now shows the dep + version, the `Arc<dyn ...>` coercion, and that a cancel returns `Err(Error::Cancelled)`.

README is markdown-only (not doctest-included); every symbol/type was verified by reading source. CHANGELOG `[Unreleased]/Fixed` updated.