### PR TITLE
docs(zenjxl-decoder): correct documented default max_pixels (1<<28, not 2^30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ This project is a fork of [libjxl/jxl-rs](https://github.com/libjxl/jxl-rs). The
   image area). Pure internal change — no public API or output change. (#35)
 
 ### Fixed
+- docs: the `JxlDecoderLimits::max_pixels` field doc stated the default was
+  `2^30 (~1 billion)`, but the actual default is `1 << 28` (~256 megapixels).
+  Corrected the doc comment to match the code and noted that `restrictive()`
+  lowers it to a 120-megapixel house cap. Doc-only; no behavior change. Found in
+  a production-readiness audit.
 - docs(readme): the Basic decode example now shows a real decode-to-pixels flow
   (`width`/`height`/`data`/`channels` off `JxlImage`) instead of stopping short,
   and documents the output format (8-bit interleaved RGBA8/GrayAlpha8, straight

--- a/zenjxl-decoder/src/api/options.rs
+++ b/zenjxl-decoder/src/api/options.rs
@@ -28,8 +28,9 @@ use std::sync::Arc;
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct JxlDecoderLimits {
-    /// Maximum total pixels (width × height). Default: 2^30 (~1 billion).
+    /// Maximum total pixels (width × height). Default: 1 << 28 (~256 megapixels).
     /// This is checked early during header parsing.
+    /// [`JxlDecoderLimits::restrictive`] lowers this to a 120-megapixel house cap.
     pub max_pixels: Option<usize>,
 
     /// Maximum number of extra channels (alpha, depth, etc.). Default: 256.


### PR DESCRIPTION
Doc-only fix found in a production-readiness audit.

The `JxlDecoderLimits::max_pixels` field doc (`src/api/options.rs`) overstated the default: it claimed `2^30 (~1 billion)`, but the actual default in `JxlDecoderLimits::default()` is `Some(1 << 28)` (~256 megapixels). This corrects the doc comment to match the code and adds a one-line note that `restrictive()` lowers the cap to 120 megapixels.

- `src/api/options.rs:31` doc comment corrected; line 33 note added.
- No code values changed — documentation only.
- Other `2^30` mentions in the crate are correct in their own context (the JXL spec hard limit in `headers/size.rs`, the 1 GB `max_memory_bytes` default, and historical CHANGELOG entries) and were left untouched.
- CHANGELOG `Fixed` entry added.

No `cargo` run (machine-safety: another heavy build is active; CI verifies).