### PR TITLE
test(heaptrack): add a decode allocation-profiling harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ This project is a fork of [libjxl/jxl-rs](https://github.com/libjxl/jxl-rs). The
   only the frame/render/api layer carries the wrapper. (#28)
 
 ### Added
+- `examples/heaptrack_decode.rs`: a reusable heaptrack/valgrind harness that
+  decodes a JXL file from bytes via `zenjxl_decoder::decode(..)` in a loop, for
+  profiling heap-allocation behaviour. Defaults to the committed
+  `resources/test/bike_web_q85.jxl` (2048×2560, 5.24 MP VarDCT photo) decoded 8×;
+  a path + iteration count can be passed. Driven by `just heaptrack-decode`.
+  Profiled result: heap **size** and leaks are healthy — peak 44.7 MiB (~2.1× the
+  20 MiB RGBA8 output, O(image)), and leaked allocations are pinned at 31 across
+  2/8/16 iterations (one-time statics, no per-decode growth). Allocation **count**
+  is elevated at ~29,300/decode, dominated by ~17,400/decode of small transient
+  zeroed scratch in the per-group `frame::group::dequant_and_transform_to_pixels`
+  path, including the per-pass `PassInfo::num_nzeros: [Image<u32>; 3]` already
+  flagged with an in-code `// TODO(veluca): reuse this allocation.` Tracked as a
+  resource follow-up.
 - `JxlDecoderOptions::reject_progressive` (default `false`): when `true`, decode
   fails with the new `Error::ProgressiveRejected` as soon as a progressive frame
   header is seen — before decoding its passes — for untrusted-input policies that

--- a/justfile
+++ b/justfile
@@ -14,3 +14,11 @@ api-doc:
 # Verify the committed snapshots are current
 api-doc-check:
     ZEN_API_DOC=check cargo test --manifest-path apidoc/Cargo.toml
+
+# Profile decode-from-bytes heap allocations with heaptrack (needs heaptrack installed).
+# Defaults to the committed bike_web_q85.jxl (2048x2560) decoded 8x; pass a path + iters
+# to override. Inspect with: heaptrack_print /tmp/zenjxl-ht.zst
+heaptrack-decode *ARGS:
+    cargo build -p zenjxl-decoder --release --example heaptrack_decode
+    rm -f /tmp/zenjxl-ht.zst
+    heaptrack --output /tmp/zenjxl-ht ./target/release/examples/heaptrack_decode {{ARGS}}

--- a/zenjxl-decoder/Cargo.toml
+++ b/zenjxl-decoder/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2024"
 rust-version = "1.89"
 license = "BSD-3-Clause"
 
-include = ["/src/**", "/tests/**", "/benches/**", "/LICENSE*"]
+include = ["/src/**", "/tests/**", "/benches/**", "/examples/**", "/LICENSE*"]
 
 [dependencies]
 thiserror = "2.0"
@@ -69,6 +69,11 @@ harness = false
 [[bench]]
 name = "decode_bench"
 harness = false
+
+# Heaptrack allocation-profiling harness for the decode-from-bytes path.
+# Decode is in the default feature set; no extra features needed.
+[[example]]
+name = "heaptrack_decode"
 
 [lints]
 workspace = true

--- a/zenjxl-decoder/examples/heaptrack_decode.rs
+++ b/zenjxl-decoder/examples/heaptrack_decode.rs
@@ -1,0 +1,86 @@
+//! Heaptrack harness for JPEG XL decode-from-bytes allocation profiling.
+//!
+//! Profiles the production-critical path: `zenjxl_decoder::decode(&bytes)` —
+//! decoding a JXL file (untrusted input) all the way to interleaved RGBA8 / GrayA8
+//! pixels. The goal is to surface allocation *pathologies* that don't show up in a
+//! wall-clock benchmark: a high allocation *count* relative to image size, per-pixel
+//! or per-DCT-block/per-group mallocs, large transient peaks, or unbounded growth
+//! across repeated decodes (a leak). High allocation churn hurts most under
+//! contended allocators (Windows, multi-threaded servers) where a single decode of
+//! an untrusted upload turns into thousands of lock round-trips.
+//!
+//! Usage:
+//!   cargo build -p zenjxl-decoder --release --example heaptrack_decode
+//!   heaptrack ./target/release/examples/heaptrack_decode                 # default fixture
+//!   heaptrack ./target/release/examples/heaptrack_decode <file.jxl> [iters]
+//!
+//! Then inspect:
+//!   heaptrack_print heaptrack.heaptrack_decode.*.zst | less
+//!
+//! Defaults to the committed `resources/test/bike_web_q85.jxl` (a real VarDCT
+//! photo: many 256x256 groups and 8x8 DCT blocks, so the allocation count can be
+//! judged relative to image size) decoded 8 times. A large fixture should be
+//! decoded fewer times (pass a smaller `iters`).
+
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+
+/// Resolve the default bundled fixture relative to the crate manifest so the
+/// example runs from any working directory.
+fn default_fixture() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("resources/test/bike_web_q85.jxl")
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    let path: PathBuf = match args.get(1) {
+        Some(p) => PathBuf::from(p),
+        None => default_fixture(),
+    };
+    // Default 8 iterations; a leak shows up as monotonic growth across them, and a
+    // healthy decoder's steady-state per-decode allocation count is iterations-stable.
+    let iters: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(8);
+
+    let data = std::fs::read(&path).unwrap_or_else(|e| {
+        eprintln!("failed to read {}: {e}", path.display());
+        std::process::exit(1);
+    });
+
+    // Probe once so the report can state the dimensions the alloc count is relative to.
+    match zenjxl_decoder::read_header(&data) {
+        Ok(hdr) => {
+            let (w, h) = hdr.info.size;
+            eprintln!("fixture: {} ({} bytes on disk)", path.display(), data.len());
+            eprintln!(
+                "  decoded image: {}x{} ({:.2} MP)",
+                w,
+                h,
+                (w as f64 * h as f64) / 1.0e6
+            );
+        }
+        Err(e) => {
+            eprintln!("probe (read_header) failed for {}: {e:?}", path.display());
+            std::process::exit(1);
+        }
+    }
+
+    eprintln!("decoding {iters}x via zenjxl_decoder::decode(..) ...");
+
+    let mut total_pixels: u64 = 0;
+    for i in 0..iters {
+        let image = zenjxl_decoder::decode(&data).unwrap_or_else(|e| {
+            eprintln!("decode iteration {i} failed: {e:?}");
+            std::process::exit(1);
+        });
+        total_pixels += image.width as u64 * image.height as u64;
+        // Consume the decoded buffer so the optimizer can't elide the decode or the
+        // allocation of the output Vec.
+        black_box(&image.data);
+        black_box(image.width);
+        black_box(image.height);
+        black_box(image.channels);
+    }
+
+    eprintln!("done: decoded {total_pixels} total pixels across {iters} iterations");
+}


### PR DESCRIPTION
Adds a reusable `zenjxl-decoder/examples/heaptrack_decode.rs` for profiling the **decode-from-untrusted-bytes** heap-allocation behaviour under heaptrack/valgrind, mirroring the harness now in `heic`/`zenjpeg`/`zenpng`. It decodes a JXL file via the public `zenjxl_decoder::decode(..)` in a loop (default 8x), accepts a `<path> [iters]` override, and is driven by `just heaptrack-decode`. `examples/**` is added to the package `include` so the declared `[[example]]` packages cleanly.

Default fixture: the committed `resources/test/bike_web_q85.jxl` (2048x2560, 5.24 MP real VarDCT photo -> ~80 256x256 groups, meaningful block count for judging the per-decode allocation count).

## Profiled result (heaptrack 1.3.0, release w/ debuginfo, no target-cpu=native)

| metric | value | note |
|---|---|---|
| peak heap | **44.7 MiB** | ~2.1x the 20 MiB RGBA8 output -> O(image), **healthy** |
| total alloc count | **234,333** (~29,300/decode @ 8 iters) | elevated (see below) |
| temporary allocs | 78,267 | ~9,800/decode |
| leaked | 2.10 MiB / **31 allocs** | **one-time statics** (see leak test) |
| total runtime | 1.10 s | |

**Heap size and leaks are healthy.** Peak is bounded and dominated by the O(image) group/frame/output buffers. The leak is **not per-decode**: leaked-allocation count is exactly **31 at 2, 8, and 16 iterations** (total allocs scale linearly: 58,624 / 234,333 / 468,614 = ~29,300/decode), so it's one-time process/static init (thread pools / lazy statics), not unbounded growth.

**Allocation count is elevated but concentrated.** The dominant call-site is the per-group dequant+IDCT path:

- `frame::group::dequant_and_transform_to_pixels` -> **139,152 allocs, 2.11 MiB peak** (~17,400/decode) — small transient zeroed scratch (`alloc::vec::from_elem`), allocated-and-freed per pass / per varblock. This includes the per-pass `PassInfo::num_nzeros: [Image<u32>; 3]` (`src/frame/group.rs:371`), which already carries an in-code `// TODO(veluca): reuse this allocation.`

The group-level `GroupDecodeCache` already reuses `scratch` / `coeffs_storage` buffers, so this is the next layer of the same reuse work, not a new design problem. Tracked as a resource follow-up: #40.

run-heavy: build peak-RSS 1.41 GiB / min-avail 48986 MiB; heaptrack run peak-RSS 0.23 GiB / min-avail 51532 MiB.
