### PR TITLE
perf(frame): reuse per-varblock dequant scratch (cuts ~29k allocs/decode, closes #40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,22 @@ This project is a fork of [libjxl/jxl-rs](https://github.com/libjxl/jxl-rs). The
   surfaced on the probe. (966f9c5)
 
 ### Changed
+- VarDCT decode no longer makes per-block / per-pass scratch heap allocations on
+  the `frame::group::dequant_and_transform_to_pixels` hot path. The AFV transform
+  arms allocated three transient `Vec<f32>`s per AFV block (a 64-element input
+  snapshot plus two `4x4`/`4x8` scratch buffers); these are now fixed-size stack
+  arrays, matching the sibling IDENTITY/DCT2X2/DCT4X4 arms. The per-pass
+  `PassInfo::num_nzeros: [Image<u32>; 3]` non-zero-count maps (which carried an
+  in-code `// TODO(veluca): reuse this allocation.`) are now reused across groups
+  via a pool on `VarDctBuffers`, resized only on a dimension change and re-zeroed
+  per group. Measured on `resources/test/bike_web_q85.jxl` (5.24 MP) via
+  `examples/heaptrack_decode`: total allocations dropped from ~29,300/decode to
+  ~3,200/decode (234,333 → 25,805 over 8 iterations, −89%), with the
+  `dequant_and_transform_to_pixels` allocation site eliminated entirely. Peak heap
+  (44.7 MiB) and leaked allocations (31, all one-time statics) are unchanged.
+  Pure internal allocation-lifetime change, gated on a bit-identical-output
+  regression test (`tests/decode_bit_identical.rs`) — no public API or output
+  change. (closes #40)
 - `get_distinct_slices` (the per-row multi-slice helper on the modular /
   VarDCT-LF decode hot path) no longer heap-allocates a transient `Vec` on every
   call. Because the slice count `S` is a const generic, the scratch now lives on

--- a/zenjxl-decoder/src/frame/group.rs
+++ b/zenjxl-decoder/src/frame/group.rs
@@ -34,6 +34,12 @@ pub struct VarDctBuffers {
     pub transform_buffer: [Vec<f32>; 3],
     /// Coefficient storage for single-pass decoding (when hf_coefficients is None)
     pub coeffs_storage: Vec<i32>,
+    /// Per-pass non-zero-count prediction maps, reused across groups. One
+    /// `[Image<u32>; 3]` (X/Y/B planes) per pass. Each group resizes (only on a
+    /// dimension change) and zeroes the entries it needs via
+    /// [`VarDctBuffers::prepare_num_nzeros`], so this allocation is amortized
+    /// across every group rather than rebuilt per pass per group (issue #40).
+    num_nzeros: Vec<[Image<u32>; 3]>,
 }
 
 impl VarDctBuffers {
@@ -52,14 +58,49 @@ impl VarDctBuffers {
             ],
             coeffs_storage: Vec::try_from_elem(0, 3 * GROUP_DIM * GROUP_DIM)
                 .map_err(|_| Error::ImageOutOfMemory(3 * GROUP_DIM * GROUP_DIM, 1))?,
+            num_nzeros: Vec::new(),
         })
     }
 
-    /// Reset buffers for reuse. Only coeffs_storage needs zeroing because
-    /// coefficients are accumulated with `+=`. scratch and transform_buffer are
-    /// fully written by dequant_block/copy_from_slice before each read.
-    pub fn reset(&mut self) {
-        self.coeffs_storage.fill(0);
+    /// Prepares the reused per-pass `num_nzeros` maps for one group, sizing and
+    /// zeroing the first `num_passes` entries.
+    ///
+    /// Each pass needs three planes sized `sizes[c]` (the block-group rect after
+    /// per-channel sub-sampling). Entries are reused in place when their
+    /// dimensions already match — only the cells are re-zeroed; a dimension
+    /// change (edge groups, or a pool grown for a new frame) reallocates the
+    /// affected plane. After this call the first `num_passes` entries are fully
+    /// zeroed, matching the freshly-`new_tracked` images this replaced, which is
+    /// required for correctness: `predict_num_nonzeros` reads not-yet-written
+    /// neighbour cells that must read as zero.
+    ///
+    /// Returns `()` rather than the slice so the caller can split-borrow the
+    /// `num_nzeros` field directly afterward (keeping it disjoint from the other
+    /// reused buffers borrowed across the decode loop).
+    fn prepare_num_nzeros(
+        &mut self,
+        num_passes: usize,
+        sizes: [(usize, usize); 3],
+        tracker: &MemoryTracker,
+    ) -> Result<()> {
+        // Grow the pool to cover this frame's pass count (only ever grows).
+        while self.num_nzeros.len() < num_passes {
+            self.num_nzeros.push([
+                Image::new_tracked(sizes[0], tracker)?,
+                Image::new_tracked(sizes[1], tracker)?,
+                Image::new_tracked(sizes[2], tracker)?,
+            ]);
+        }
+        for planes in self.num_nzeros[..num_passes].iter_mut() {
+            for (plane, &size) in planes.iter_mut().zip(sizes.iter()) {
+                if plane.size() == size {
+                    plane.fill(0);
+                } else {
+                    *plane = Image::new_tracked(size, tracker)?;
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -361,24 +402,24 @@ simd_function!(
     }
 );
 
-struct PassInfo<'a, 'b> {
+struct PassInfo<'a, 'b, 'c> {
     histogram_index: usize,
     reader: Option<SymbolReader>,
     br: &'a mut BitReader<'b>,
     shift: u32,
     pass: usize,
-    // TODO(veluca): reuse this allocation.
-    num_nzeros: [Image<u32>; 3],
+    /// Borrowed (X/Y/B) non-zero-count maps, owned and reused by
+    /// [`VarDctBuffers::num_nzeros`] and pre-sized + zeroed for this group.
+    num_nzeros: &'c mut [Image<u32>; 3],
 }
 
-impl<'a, 'b> PassInfo<'a, 'b> {
+impl<'a, 'b, 'c> PassInfo<'a, 'b, 'c> {
     fn new(
         hf_global: &HfGlobalState,
         frame_header: &FrameHeader,
-        block_group_rect: Rect,
         pass: usize,
         br: &'a mut BitReader<'b>,
-        tracker: &MemoryTracker,
+        num_nzeros: &'c mut [Image<u32>; 3],
     ) -> Result<Self> {
         let num_histo_bits = hf_global.num_histograms.ceil_log2();
         debug!(?pass);
@@ -404,29 +445,6 @@ impl<'a, 'b> PassInfo<'a, 'b> {
         } else {
             0
         };
-        let num_nzeros = [
-            Image::new_tracked(
-                (
-                    block_group_rect.size.0 >> frame_header.hshift(0),
-                    block_group_rect.size.1 >> frame_header.vshift(0),
-                ),
-                tracker,
-            )?,
-            Image::new_tracked(
-                (
-                    block_group_rect.size.0 >> frame_header.hshift(1),
-                    block_group_rect.size.1 >> frame_header.vshift(1),
-                ),
-                tracker,
-            )?,
-            Image::new_tracked(
-                (
-                    block_group_rect.size.0 >> frame_header.hshift(2),
-                    block_group_rect.size.1 >> frame_header.vshift(2),
-                ),
-                tracker,
-            )?,
-        ];
 
         Ok(Self {
             histogram_index,
@@ -463,17 +481,21 @@ pub fn decode_vardct_group(
 
     let block_group_rect = frame_header.block_group_rect(group);
     debug!(?block_group_rect);
+    // Per-channel (X/Y/B) dimensions of the non-zero-count maps for this group.
+    let num_nzeros_sizes: [(usize, usize); 3] = core::array::from_fn(|c| {
+        (
+            block_group_rect.size.0 >> frame_header.hshift(c),
+            block_group_rect.size.1 >> frame_header.vshift(c),
+        )
+    });
+    // Size + zero the reused per-pass num_nzeros maps, then split-borrow the
+    // field directly so it stays disjoint from scratch/coeffs/transform_buffer.
+    buffers.prepare_num_nzeros(passes.len(), num_nzeros_sizes, tracker)?;
     let mut pass_info = passes
         .iter_mut()
-        .map(|(pass, br)| {
-            PassInfo::new(
-                hf_global,
-                frame_header,
-                block_group_rect,
-                *pass,
-                br,
-                tracker,
-            )
+        .zip(buffers.num_nzeros.iter_mut())
+        .map(|((pass, br), num_nzeros)| {
+            PassInfo::new(hf_global, frame_header, *pass, br, num_nzeros)
         })
         .collect::<Result<SmallVec<[_; 4]>>>()?;
 
@@ -484,7 +506,10 @@ pub fn decode_vardct_group(
     let uses_local_coeffs = hf_coefficients.is_none();
     let single_pass = pass_info.len() == 1;
     if uses_local_coeffs && !single_pass {
-        buffers.reset();
+        // Inlined `buffers.reset()`: a direct field access keeps this borrow
+        // disjoint from `buffers.num_nzeros` (held by `pass_info`) and from the
+        // scratch/transform_buffer borrows taken below.
+        buffers.coeffs_storage.fill(0);
     }
     let scratch = &mut buffers.scratch;
     let color_correlation_params = lf_global.color_correlation_params.as_ref().unwrap();

--- a/zenjxl-decoder/src/transforms/transform.rs
+++ b/zenjxl-decoder/src/transforms/transform.rs
@@ -317,8 +317,9 @@ fn afv_transform_to_pixels<D: SimdDescriptor>(
         block00 + block10 - block01,
         block00 - block10,
     ];
-    // IAFV: (even, even) positions.
-    let mut coeff: Vec<f32> = vec![0.0; 4 * 4];
+    // IAFV: (even, even) positions. Fixed-size stack scratch avoids a per-block
+    // heap allocation (issue #40); every element is written before it is read.
+    let mut coeff = [0.0f32; 4 * 4];
     for iy in 0..4 {
         for ix in 0..4 {
             coeff[iy * 4 + ix] = if ix == 0 && iy == 0 {
@@ -328,7 +329,7 @@ fn afv_transform_to_pixels<D: SimdDescriptor>(
             };
         }
     }
-    let mut block: Vec<f32> = vec![0.0; 4 * 8];
+    let mut block = [0.0f32; 4 * 8];
     avfidct4x4(&coeff, &mut block);
     for iy in 0..4 {
         let block_y = if afv_y == 1 { 3 - iy } else { iy };
@@ -507,22 +508,27 @@ pub fn transform_to_pixels_impl<D: SimdDescriptor>(
         ),
         HfTransformType::AFV0 => {
             transform_buffer[0] = lf[0];
-            let block: Vec<f32> = transform_buffer[0..64].to_vec();
+            // Snapshot the 64 input coefficients onto the stack so the transform
+            // can read them while overwriting `transform_buffer` in place. A
+            // fixed-size array avoids the per-block heap allocation that
+            // `.to_vec()` would incur (see issue #40); the sibling IDENTITY/DCT*
+            // arms below already use this pattern.
+            let block: [f32; 64] = transform_buffer[0..64].try_into().unwrap();
             afv_transform_to_pixels::<D>(d, 0, &block, &mut transform_buffer[0..64]);
         }
         HfTransformType::AFV1 => {
             transform_buffer[0] = lf[0];
-            let block: Vec<f32> = transform_buffer[0..64].to_vec();
+            let block: [f32; 64] = transform_buffer[0..64].try_into().unwrap();
             afv_transform_to_pixels::<D>(d, 1, &block, &mut transform_buffer[0..64]);
         }
         HfTransformType::AFV2 => {
             transform_buffer[0] = lf[0];
-            let block: Vec<f32> = transform_buffer[0..64].to_vec();
+            let block: [f32; 64] = transform_buffer[0..64].try_into().unwrap();
             afv_transform_to_pixels::<D>(d, 2, &block, &mut transform_buffer[0..64]);
         }
         HfTransformType::AFV3 => {
             transform_buffer[0] = lf[0];
-            let block: Vec<f32> = transform_buffer[0..64].to_vec();
+            let block: [f32; 64] = transform_buffer[0..64].try_into().unwrap();
             afv_transform_to_pixels::<D>(d, 3, &block, &mut transform_buffer[0..64]);
         }
         HfTransformType::IDENTITY => {

--- a/zenjxl-decoder/tests/decode_bit_identical.rs
+++ b/zenjxl-decoder/tests/decode_bit_identical.rs
@@ -1,0 +1,107 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//! Bit-identical decode regression gate for the VarDCT scratch-buffer reuse in
+//! issue #40.
+//!
+//! The fix (reusing the per-pass `num_nzeros` maps and replacing the per-block
+//! `Vec` scratch in the AFV transform with stack arrays) is a pure allocation
+//! lifetime change: it must not alter a single output pixel. Buffer reuse that
+//! fails to fully reset state would silently corrupt the decode — exactly the
+//! class of bug this asserts against.
+//!
+//! The reference hashes below were captured on the clean `main` commit
+//! (ac1d907, the parent of this change) by decoding each fixture through the
+//! public `zenjxl_decoder::decode` API. If a future change alters decoded
+//! output for these fixtures, this test fails loudly rather than shipping a
+//! pixel regression. Update the constants ONLY after independently confirming
+//! the output change is intended.
+
+use std::path::Path;
+
+/// FNV-1a/64 over the full interleaved RGBA byte buffer. A whole-buffer content
+/// hash: any pixel difference (even one bit) changes it.
+fn fnv1a_64(bytes: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01B3);
+    }
+    h
+}
+
+struct Expected {
+    file: &'static str,
+    width: usize,
+    height: usize,
+    channels: usize,
+    len: usize,
+    hash: u64,
+}
+
+/// Decode `file` and assert its dimensions, channel count, byte length, and a
+/// stable content hash all match the clean-`main` reference.
+fn assert_decode_matches(e: &Expected) {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("resources/test")
+        .join(e.file);
+    let data = std::fs::read(&path)
+        .unwrap_or_else(|err| panic!("failed to read fixture {}: {err}", path.display()));
+
+    let image = zenjxl_decoder::decode(&data)
+        .unwrap_or_else(|err| panic!("decode failed for {}: {err:?}", e.file));
+
+    assert_eq!(image.width, e.width, "{}: width changed", e.file);
+    assert_eq!(image.height, e.height, "{}: height changed", e.file);
+    assert_eq!(
+        image.channels, e.channels,
+        "{}: channel count changed",
+        e.file
+    );
+    assert_eq!(
+        image.data.len(),
+        e.len,
+        "{}: output byte length changed",
+        e.file
+    );
+    assert_eq!(
+        fnv1a_64(&image.data),
+        e.hash,
+        "{}: decoded pixels differ from the clean-main reference \
+         (0x{:016x} != expected 0x{:016x}) -- a buffer-reuse change has corrupted output",
+        e.file,
+        fnv1a_64(&image.data),
+        e.hash,
+    );
+}
+
+/// `bike_web_q85.jxl` is the 5.24 MP VarDCT photo used by the allocation
+/// profiler in `examples/heaptrack_decode.rs`; it exercises the AFV transform
+/// and `num_nzeros` paths touched by the issue #40 fix.
+#[test]
+fn bike_web_q85_decode_is_bit_identical() {
+    assert_decode_matches(&Expected {
+        file: "bike_web_q85.jxl",
+        width: 2048,
+        height: 2560,
+        channels: 4,
+        len: 20_971_520,
+        hash: 0x14af_5870_ea86_5a92,
+    });
+}
+
+/// A second VarDCT fixture at a different quality, so the gate covers more than
+/// one coefficient distribution / block-type mix.
+#[test]
+fn bike_web_q75_decode_is_bit_identical() {
+    assert_decode_matches(&Expected {
+        file: "bike_web_q75.jxl",
+        width: 2048,
+        height: 2560,
+        channels: 4,
+        len: 20_971_520,
+        hash: 0x9714_2587_6e6a_59e3,
+    });
+}


### PR DESCRIPTION
Closes #40.

## What

Eliminates the per-block / per-pass transient heap allocations on the VarDCT decode hot path (`frame::group::dequant_and_transform_to_pixels`), the top allocation call-site identified in #40.

Two reuse changes, both pure allocation-lifetime (no algorithm change):

1. **AFV transform scratch → stack arrays** (`transforms/transform.rs`). The four `AFV0..AFV3` arms each allocated a 64-element `Vec<f32>` via `.to_vec()` to snapshot the input coefficients, and `afv_transform_to_pixels` allocated two more (`vec![0.0; 4*4]` + `vec![0.0; 4*8]`) per call — three transient heap allocs per AFV block. These are now fixed-size stack arrays (`[f32; 64]`, `[f32; 16]`, `[f32; 32]`), exactly matching the sibling `IDENTITY` / `DCT2X2` / `DCT4X4` / `DCT8X4` / `DCT4X8` arms that already use `try_into().unwrap()` stack arrays. This was the dominant churn.

2. **`PassInfo::num_nzeros` → reused pool** (`frame/group.rs`). The per-pass non-zero-count maps `[Image<u32>; 3]` (which carried the in-code `// TODO(veluca): reuse this allocation.`) were rebuilt per pass per group. They now live in a reused `Vec<[Image<u32>; 3]>` pool on `VarDctBuffers` (the same struct that already pools `scratch` / `coeffs_storage` / `transform_buffer`). `VarDctBuffers::prepare_num_nzeros` grows the pool to the pass count, resizes a plane only on a dimension change (edge groups), and **re-zeroes** every plane per group — preserving the fresh-zero invariant that `predict_num_nonzeros` relies on (it reads not-yet-written neighbour cells, which must read as zero). `PassInfo` now borrows its maps from the pool. The only-call-site `VarDctBuffers::reset()` (internal, `mod group` is private) was inlined to `coeffs_storage.fill(0)` to keep the borrow disjoint from the pool field, and removed as dead code.

## Allocation count: before → after

Measured with `examples/heaptrack_decode` (added in #39) on the committed `resources/test/bike_web_q85.jxl` (2048×2560, 5.24 MP VarDCT photo), release + debuginfo, **no** `target-cpu=native`, 8 decodes:

| metric | before (clean `main` ac1d907) | after | delta |
|---|---|---|---|
| total allocations (8 decodes) | **234,333** | **25,805** | −208,528 (−89%) |
| per-decode allocations | **~29,300** | **~3,200** | −89% |
| temporary allocations | 78,267 | 9,387 | −88% |
| peak heap | 44.74 MiB | 44.74 MiB | unchanged |
| leaked allocations | 31 | 31 | unchanged (one-time statics, no leak) |

In the after-profile the `dequant_and_transform_to_pixels` / `transforms/transform.rs` allocation frames are **gone entirely** (0 hits), and `prepare_num_nzeros` does not appear as a hot site (it allocates once, then reuses).

## Correctness gate — bit-identical output (zero-tolerance)

Buffer reuse that fails to fully reset state would silently corrupt pixels, so this is gated on a committed regression test, `tests/decode_bit_identical.rs`:

- Reference hashes captured on clean `main` (ac1d907, the parent commit) **before** the change, by decoding each fixture through the public `zenjxl_decoder::decode` API.
- After the change, both committed VarDCT fixtures decode to **byte-for-byte identical** RGBA output:
  - `bike_web_q85.jxl`: 2048×2560, RGBA, 20,971,520 bytes, FNV-1a `0x14af5870ea865a92` (clean == after)
  - `bike_web_q75.jxl` (second fixture, different quality / coefficient mix): FNV-1a `0x971425876e6a59e3` (clean == after)
- The test asserts width/height/channels/byte-length **and** a whole-buffer content hash, so any one-bit pixel difference fails loudly.

Verification gates, all green:
- `cargo test -p zenjxl-decoder --release --test decode_bit_identical` — 2/2 pass
- `cargo test -p zenjxl-decoder --release` — full suite **1266 passed, 0 failed** (32 pre-existing ignores; **zero** added by this PR)
- `cargo clippy -p zenjxl-decoder --all-targets` — clean
- `cargo fmt -p zenjxl-decoder --check` — clean

No public API change (`mod group` is private; `VarDctBuffers` and `PassInfo` are crate-internal).
